### PR TITLE
Allow deeply nested objects to be returned from VIEWS

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -1,15 +1,14 @@
 function deepMapViews(views, func) {
-  if (typeof views.render === 'function') {
-    return func(views);
-  } else if (Array.isArray(views)) {
+  if (Array.isArray(views)) {
     return views.map(view => deepMapViews(view, func));
-  } else if (typeof views === 'object') {
+  } else if (typeof views === 'object' && typeof views.render !== 'function') {
     return Object.keys(views).reduce((renderers, key) => {
       return Object.assign({}, renderers, {
         [key]: deepMapViews(views[key], func),
       });
     }, {});
   }
+  return func(views);
 }
 
 export default class View {

--- a/lib/view.js
+++ b/lib/view.js
@@ -1,13 +1,24 @@
+function deepMapViews(views, func) {
+  if (typeof views.render === 'function') {
+    return func(views);
+  } else if (Array.isArray(views)) {
+    return views.map(view => deepMapViews(view, func));
+  } else if (typeof views === 'object') {
+    return Object.keys(views).reduce((renderers, key) => {
+      return Object.assign({}, renderers, {
+        [key]: deepMapViews(views[key], func),
+      });
+    }, {});
+  }
+}
+
 export default class View {
   constructor(parent, initialState={}) {
     this.parent = parent;
     this.initialState = initialState;
     this._template = this.TEMPLATE;
     this._views = this.VIEWS;
-    this._viewRenderers = Object.keys(this._views).reduce((renderers, vname) => {
-      const view = this._views[vname];
-      return Object.assign({}, renderers, {[vname]: view.render.bind(view)});
-    }, {});
+    this._viewRenderers = deepMapViews(this._views, view => view.render.bind(view));
   }
 
   get TEMPLATE() {
@@ -40,6 +51,6 @@ export default class View {
   setApp(app) {
     this.app = app;
     Object.assign(app.state, this.initialState);
-    Object.keys(this._views).forEach(v => this._views[v].setApp(app));
+    deepMapViews(this._views, view => view.setApp(app));
   }
 }


### PR DESCRIPTION
I'd like to be able to do things like
```
  get VIEWS() {
    return {
      panes: [
        {header: new PaneAHeaderView(this), content: new PaneAContentView(this)},
        {header: new PaneBHeaderView(this), content: new PaneBContentView(this)},
      ],
    };
  }
```
so I can have templates like
```
ul.panes
  for pane in views.panes
    li.pane
      .header= pane.header(state)
      .content= pane.content(state)
```