### PR TITLE
Make it possible to call update on a component before it's attached

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -17,7 +17,7 @@ export default class Component extends WebComponent {
       routes: {},
       template: () => { throw 'No template provided by Component subclass'; },
     }, this.config);
-    this.state = this.state || {};
+    this.state = {};
   }
 
   attachedCallback() {
@@ -41,7 +41,6 @@ export default class Component extends WebComponent {
     } else {
       this.isPanelRoot = true;
       this.$panelRoot = this;
-      this.state = this.state || {};
       this.router = new Router(this, {historyMethod: this.historyMethod});
     }
     this.app = this.$panelRoot;
@@ -61,6 +60,8 @@ export default class Component extends WebComponent {
     if (Object.keys(this.getConfig('routes')).length) {
       this.navigate(window.location.hash);
     }
+
+    this.initialized = true;
   }
 
   detachedCallback() {
@@ -86,7 +87,7 @@ export default class Component extends WebComponent {
   }
 
   update(stateUpdate={}) {
-    if (typeof this.app === 'undefined') {
+    if (!this.initialized) {
       this.state = Object.assign({}, this.state, stateUpdate);
     } else if (this.isPanelRoot) {
       const updateHash = '$fragment' in stateUpdate && stateUpdate.$fragment !== this.state.$fragment;

--- a/lib/component.js
+++ b/lib/component.js
@@ -17,6 +17,7 @@ export default class Component extends WebComponent {
       routes: {},
       template: () => { throw 'No template provided by Component subclass'; },
     }, this.config);
+    this.state = this.state || {};
   }
 
   attachedCallback() {
@@ -85,7 +86,9 @@ export default class Component extends WebComponent {
   }
 
   update(stateUpdate={}) {
-    if (this.isPanelRoot) {
+    if (typeof this.app === 'undefined') {
+      this.state = Object.assign({}, this.state, stateUpdate);
+    } else if (this.isPanelRoot) {
       const updateHash = '$fragment' in stateUpdate && stateUpdate.$fragment !== this.state.$fragment;
 
       Object.assign(this.state, stateUpdate);

--- a/test/test-component.js
+++ b/test/test-component.js
@@ -24,6 +24,18 @@ describe('Simple Component instance', function() {
         done();
       });
     });
+
+    it('allows updating', function(done) {
+      el.update({foo: 'not bar'});
+      document.body.appendChild(el);
+      expect(el.state.foo).to.equal('not bar');
+      window.requestAnimationFrame(function() {
+        expect(el.state.foo).to.equal('not bar');
+        expect(el.textContent).to.contain('Value of foo: not bar');
+        expect(el.textContent).to.contain('Foo capitalized: Not bar');
+        done();
+      });
+    });
   });
 
   context('when attached to DOM', function() {

--- a/test/test-component.js
+++ b/test/test-component.js
@@ -25,7 +25,7 @@ describe('Simple Component instance', function() {
       });
     });
 
-    it('allows updating', function(done) {
+    it('allows updates and applies them when attached', function(done) {
       el.update({foo: 'not bar'});
       document.body.appendChild(el);
       expect(el.state.foo).to.equal('not bar');

--- a/test/test-component.js
+++ b/test/test-component.js
@@ -76,52 +76,82 @@ describe('Simple Component instance', function() {
 describe('Nested Component instance', function() {
   var el, childEl;
 
-  beforeEach(function(done) {
-    document.body.innerHTML = '';
-    el = document.createElement('nested-app');
-    document.body.appendChild(el);
-    window.requestAnimationFrame(function() {
-      childEl = el.getElementsByTagName('nested-child')[0];
-      done();
+  context('before attached to DOM', function() {
+    beforeEach(function(done) {
+      document.body.innerHTML = '';
+      el = document.createElement('nested-app');
+    });
+
+    it('passes state updates from parent to child', function(done) {
+      el.update({animal: 'capybara'});
+      document.body.appendChild(el);
+      expect(childEl.state.animal).to.equal('capybara');
+      window.requestAnimationFrame(function() {
+        expect(childEl.textContent).to.include('animal: capybara');
+        done();
+      });
+    });
+
+    it('passes state updates from child to parent', function(done) {
+      childEl.update({title: 'new title'});
+      document.body.appendChild(el);
+      expect(el.state.title).to.equal('new title');
+      window.requestAnimationFrame(function() {
+        expect(el.textContent).to.include('Nested app: new title');
+        expect(childEl.textContent).to.include('parent title: new title');
+        done();
+      });
     });
   });
 
-  it('renders the parent component', function() {
-    expect(document.getElementsByClassName('nested-foo')).to.have.lengthOf(1);
-    expect(el.children).to.have.lengthOf(1);
-    expect(el.children[0].className).to.equal('nested-foo');
-  });
-
-  it('renders the child component', function() {
-    expect(document.getElementsByClassName('nested-foo-child')).to.have.lengthOf(1);
-    expect(childEl.children[0].className).to.equal('nested-foo-child');
-  });
-
-  it('passes parent state to the child component', function() {
-    expect(childEl.textContent).to.include('parent title: test');
-  });
-
-  it('passes attributes to the child component', function() {
-    expect(childEl.textContent).to.include('animal: llama');
-  });
-
-  it('passes state updates from parent to child', function(done) {
-    expect(childEl.textContent).to.include('animal: llama');
-    el.update({animal: 'capybara'});
-    window.requestAnimationFrame(function() {
-      expect(childEl.textContent).to.include('animal: capybara');
-      done();
+  context('when attached to DOM', function() {
+    beforeEach(function(done) {
+      document.body.innerHTML = '';
+      el = document.createElement('nested-app');
+      document.body.appendChild(el);
+      window.requestAnimationFrame(function() {
+        childEl = el.getElementsByTagName('nested-child')[0];
+        done();
+      });
     });
-  });
 
-  it('passes state updates from child to parent', function(done) {
-    expect(el.textContent).to.include('Nested app: test');
-    expect(childEl.textContent).to.include('parent title: test');
-    childEl.update({title: 'new title'});
-    window.requestAnimationFrame(function() {
-      expect(el.textContent).to.include('Nested app: new title');
-      expect(childEl.textContent).to.include('parent title: new title');
-      done();
+    it('renders the parent component', function() {
+      expect(document.getElementsByClassName('nested-foo')).to.have.lengthOf(1);
+      expect(el.children).to.have.lengthOf(1);
+      expect(el.children[0].className).to.equal('nested-foo');
+    });
+
+    it('renders the child component', function() {
+      expect(document.getElementsByClassName('nested-foo-child')).to.have.lengthOf(1);
+      expect(childEl.children[0].className).to.equal('nested-foo-child');
+    });
+
+    it('passes parent state to the child component', function() {
+      expect(childEl.textContent).to.include('parent title: test');
+    });
+
+    it('passes attributes to the child component', function() {
+      expect(childEl.textContent).to.include('animal: llama');
+    });
+
+    it('passes state updates from parent to child', function(done) {
+      expect(childEl.textContent).to.include('animal: llama');
+      el.update({animal: 'capybara'});
+      window.requestAnimationFrame(function() {
+        expect(childEl.textContent).to.include('animal: capybara');
+        done();
+      });
+    });
+
+    it('passes state updates from child to parent', function(done) {
+      expect(el.textContent).to.include('Nested app: test');
+      expect(childEl.textContent).to.include('parent title: test');
+      childEl.update({title: 'new title'});
+      window.requestAnimationFrame(function() {
+        expect(el.textContent).to.include('Nested app: new title');
+        expect(childEl.textContent).to.include('parent title: new title');
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
This is useful when you want to make an update call from
attributeChangedCallback, since that can occur before the
attachedCallback is executed. Init state in createCallback and
use that to store updates made before attachedCallback.