### PR TITLE
Safer rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 build
 test/fixtures/build.js
+npm-debug.log

--- a/lib/component.js
+++ b/lib/component.js
@@ -72,13 +72,12 @@ export default class Component extends WebComponent {
 
     this.loop = MainLoop(this.state, this._render.bind(this), {create, diff, patch});
     this.el.appendChild(this.loop.target);
+    this.initialized = true;
 
     if (Object.keys(this.getConfig('routes')).length) {
       this.router = new Router(this, {historyMethod: this.historyMethod});
       this.navigate(window.location.hash);
     }
-
-    this.initialized = true;
   }
 
   detachedCallback() {

--- a/lib/component.js
+++ b/lib/component.js
@@ -125,6 +125,14 @@ export default class Component extends WebComponent {
     return true;
   }
 
+  toString() {
+    try {
+      return `${this.tagName}#${this.panelID}`;
+    } catch(e) {
+      return 'UNKNOWN COMPONENT';
+    }
+  }
+
   update(stateUpdate={}) {
     if (!this.initialized) {
       Object.assign(this.state, stateUpdate);
@@ -153,10 +161,14 @@ export default class Component extends WebComponent {
 
   _render(state) {
     if (this.shouldUpdate(state)) {
-      this._rendered = this.getConfig('template')(Object.assign({}, state, {
-        $component: this,
-        $helpers: this.getConfig('helpers'),
-      }));
+      try {
+        this._rendered = this.getConfig('template')(Object.assign({}, state, {
+          $component: this,
+          $helpers: this.getConfig('helpers'),
+        }));
+      } catch(e) {
+        console.error(`Error while rendering ${this.toString()}:`, e);
+      }
     }
     return this._rendered || EMPTY_DIV;
   }

--- a/lib/component.js
+++ b/lib/component.js
@@ -109,6 +109,10 @@ export default class Component extends WebComponent {
     return this._config[item];
   }
 
+  logError() {
+    console.error(...arguments);
+  }
+
   navigate() {
     this.$panelRoot.router.navigate(...arguments);
   }
@@ -166,7 +170,7 @@ export default class Component extends WebComponent {
           $helpers: this.getConfig('helpers'),
         }));
       } catch(e) {
-        console.error(`Error while rendering ${this.toString()}`, this, e);
+        this.logError(`Error while rendering ${this.toString()}`, this, e);
       }
     }
     return this._rendered || EMPTY_DIV;

--- a/lib/component.js
+++ b/lib/component.js
@@ -166,7 +166,7 @@ export default class Component extends WebComponent {
           $helpers: this.getConfig('helpers'),
         }));
       } catch(e) {
-        console.error(`Error while rendering ${this.toString()}:`, e);
+        console.error(`Error while rendering ${this.toString()}`, this, e);
       }
     }
     return this._rendered || EMPTY_DIV;

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "build-test": "webpack --config test/fixtures/webpack.config.js",
     "prepublish": "npm run build",
     "test": "npm run build-test && npm run test-local",
-    "test-local": "wct --plugin local",
-    "test-sauce": "wct --plugin sauce"
+    "test-local": "wct --plugin local test/index.html",
+    "test-sauce": "wct --plugin sauce test/index.html"
   },
   "repository": {
     "type": "git",

--- a/test/fixtures/breakable-app.js
+++ b/test/fixtures/breakable-app.js
@@ -1,0 +1,12 @@
+import { Component, h } from '../../lib';
+
+document.registerElement('breakable-app', class extends Component {
+  get config() {
+    return {
+      template: state => h('.foo', [
+        // this will throw if state.foo does not exist
+        h('p', `Value of foo.bar: ${state.foo.bar}`),
+      ]),
+    };
+  }
+});

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -1,3 +1,4 @@
+import './breakable-app';
 import './css-no-shadow-app';
 import './nested-app';
 import './shadow-dom-app';

--- a/test/test-component.js
+++ b/test/test-component.js
@@ -285,4 +285,13 @@ describe('Rendering exception', function() {
     expect(el.logError.getCall(0).args[0]).to.contain('Error while rendering');
     expect(el.logError.getCall(0).args[0]).to.contain('BREAKABLE-APP');
   });
+
+  it('does not prevent further updates from rendering', function(done) {
+    expect(el.textContent).not.to.contain('Value of foo.bar');
+    el.update({foo: {bar: 'later success'}});
+    window.requestAnimationFrame(function() {
+      expect(el.textContent).to.contain('Value of foo.bar: later success');
+      done();
+    });
+  });
 });

--- a/test/test-component.js
+++ b/test/test-component.js
@@ -262,3 +262,27 @@ describe('Nested Component instance', function() {
     });
   });
 });
+
+
+describe('Rendering exception', function() {
+  var el;
+
+  beforeEach(function(done) {
+    document.body.innerHTML = '';
+    el = document.createElement('breakable-app');
+    el.logError = sinon.spy();
+    document.body.appendChild(el);
+    window.requestAnimationFrame(function() {
+      done();
+    });
+  });
+
+  it('does not prevent component from initializing', function() {
+    expect(el.initialized).to.be.ok;
+  });
+
+  it('logs an error', function() {
+    expect(el.logError.getCall(0).args[0]).to.contain('Error while rendering');
+    expect(el.logError.getCall(0).args[0]).to.contain('BREAKABLE-APP');
+  });
+});

--- a/test/test-component.js
+++ b/test/test-component.js
@@ -6,6 +6,12 @@ describe('Simple Component instance', function() {
     el = document.createElement('simple-app');
   });
 
+  describe('toString()', function() {
+    it('includes the tag name', function() {
+      expect(el.toString()).to.contain('SIMPLE-APP');
+    });
+  });
+
   context('before attached to DOM', function() {
     it('does not affect the DOM', function(done) {
       expect(document.getElementsByClassName('foo')).to.be.empty;


### PR DESCRIPTION
Changes some behavior around initialization and rendering so that template-rendering exceptions don't break the component. Fixes existing bad behavior:

- a rendering exception during the creation of the loop object would
throw synchronously and leave the component in a half-initialized
state (`this.loop` undefined, `this.initialized` not true, but element
attached to DOM nonetheless).

- a rendering exception during subsequent updates could lead to
main-loop's dreaded "Unexpected update occurred in loop" in
future passes because it didn't clean up its internal mutex.