### PR TITLE
include stack trace in error log when a view template throws an exception

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '6.2'
+  - '6.9'
   - '4.2'
 before_script:
   - npm run build-test

--- a/lib/component.js
+++ b/lib/component.js
@@ -297,7 +297,7 @@ class Component extends WebComponent {
           $helpers: this.getConfig('helpers'),
         }));
       } catch(e) {
-        this.logError(`Error while rendering ${this.toString()}`, this, e);
+        this.logError(`Error while rendering ${this.toString()}`, this, e.stack);
       }
     }
     return this._rendered || EMPTY_DIV;


### PR DESCRIPTION
Top line of trace should take you right to the line that blew up, not the logger wrapper.