### PR TITLE
removed babelrc from files published to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 doc
 examples
 test
+.babelrc


### PR DESCRIPTION
not necessary to publish babelrc if it's getting built with babel