### PR TITLE
fix shouldUpdate() getting state update instead of full state

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -383,9 +383,13 @@ class Component extends WebComponent {
   // a full state update to one component while sending only "shared" state
   // updates to the app root.
   updateSelfAndChildren(stateUpdate, options={}) {
+    if (!this.initialized) {
+      return;
+    }
+
     const {store, cascade} = options;
-    if (this.initialized && this.shouldUpdate(stateUpdate)) {
-      Object.assign(this[store], stateUpdate);
+    Object.assign(this[store], stateUpdate);
+    if (store !== `state` || this.shouldUpdate(this[store])) {
       this.domPatcher.update(this.state);
 
       if (cascade) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -944,6 +944,7 @@
           "requires": {
             "anymatch": "1.3.0",
             "async-each": "1.0.0",
+            "fsevents": "1.1.3",
             "glob-parent": "2.0.0",
             "inherits": "2.0.1",
             "is-binary-path": "1.0.1",
@@ -1296,6 +1297,910 @@
               "integrity": "sha1-tTGSJsKdmSd99jyK7gQJOqXx058=",
               "dev": true,
               "optional": true
+            },
+            "fsevents": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+              "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "nan": "2.8.0",
+                "node-pre-gyp": "0.6.39"
+              },
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "ajv": {
+                  "version": "4.11.8",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "co": "4.6.0",
+                    "json-stable-stringify": "1.0.1"
+                  }
+                },
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "bundled": true,
+                  "dev": true
+                },
+                "aproba": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "are-we-there-yet": {
+                  "version": "1.1.4",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "delegates": "1.0.0",
+                    "readable-stream": "2.2.9"
+                  }
+                },
+                "asn1": {
+                  "version": "0.2.3",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "assert-plus": {
+                  "version": "0.2.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "asynckit": {
+                  "version": "0.4.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "aws-sign2": {
+                  "version": "0.6.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "aws4": {
+                  "version": "1.6.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "balanced-match": {
+                  "version": "0.4.2",
+                  "bundled": true,
+                  "dev": true
+                },
+                "bcrypt-pbkdf": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "tweetnacl": "0.14.5"
+                  }
+                },
+                "block-stream": {
+                  "version": "0.0.9",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "inherits": "2.0.3"
+                  }
+                },
+                "boom": {
+                  "version": "2.10.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
+                },
+                "brace-expansion": {
+                  "version": "1.1.7",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "balanced-match": "0.4.2",
+                    "concat-map": "0.0.1"
+                  }
+                },
+                "buffer-shims": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "caseless": {
+                  "version": "0.12.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "co": {
+                  "version": "4.6.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "code-point-at": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "delayed-stream": "1.0.0"
+                  }
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "bundled": true,
+                  "dev": true
+                },
+                "console-control-strings": {
+                  "version": "1.1.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "boom": "2.10.1"
+                  }
+                },
+                "dashdash": {
+                  "version": "1.14.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "assert-plus": "1.0.0"
+                  },
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "debug": {
+                  "version": "2.6.8",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                },
+                "deep-extend": {
+                  "version": "0.4.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "delegates": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "detect-libc": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "ecc-jsbn": {
+                  "version": "0.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "jsbn": "0.1.1"
+                  }
+                },
+                "extend": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "extsprintf": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "form-data": {
+                  "version": "2.1.4",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "asynckit": "0.4.0",
+                    "combined-stream": "1.0.5",
+                    "mime-types": "2.1.15"
+                  }
+                },
+                "fs.realpath": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "fstream": {
+                  "version": "1.0.11",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "graceful-fs": "4.1.11",
+                    "inherits": "2.0.3",
+                    "mkdirp": "0.5.1",
+                    "rimraf": "2.6.1"
+                  }
+                },
+                "fstream-ignore": {
+                  "version": "1.0.5",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "fstream": "1.0.11",
+                    "inherits": "2.0.3",
+                    "minimatch": "3.0.4"
+                  }
+                },
+                "gauge": {
+                  "version": "2.7.4",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "aproba": "1.1.1",
+                    "console-control-strings": "1.1.0",
+                    "has-unicode": "2.0.1",
+                    "object-assign": "4.1.1",
+                    "signal-exit": "3.0.2",
+                    "string-width": "1.0.2",
+                    "strip-ansi": "3.0.1",
+                    "wide-align": "1.1.2"
+                  }
+                },
+                "getpass": {
+                  "version": "0.1.7",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "assert-plus": "1.0.0"
+                  },
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "glob": {
+                  "version": "7.1.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "fs.realpath": "1.0.0",
+                    "inflight": "1.0.6",
+                    "inherits": "2.0.3",
+                    "minimatch": "3.0.4",
+                    "once": "1.4.0",
+                    "path-is-absolute": "1.0.1"
+                  }
+                },
+                "graceful-fs": {
+                  "version": "4.1.11",
+                  "bundled": true,
+                  "dev": true
+                },
+                "har-schema": {
+                  "version": "1.0.5",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "har-validator": {
+                  "version": "4.2.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "ajv": "4.11.8",
+                    "har-schema": "1.0.5"
+                  }
+                },
+                "has-unicode": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "hawk": {
+                  "version": "3.1.3",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "boom": "2.10.1",
+                    "cryptiles": "2.0.5",
+                    "hoek": "2.16.3",
+                    "sntp": "1.0.9"
+                  }
+                },
+                "hoek": {
+                  "version": "2.16.3",
+                  "bundled": true,
+                  "dev": true
+                },
+                "http-signature": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "assert-plus": "0.2.0",
+                    "jsprim": "1.4.0",
+                    "sshpk": "1.13.0"
+                  }
+                },
+                "inflight": {
+                  "version": "1.0.6",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "once": "1.4.0",
+                    "wrappy": "1.0.2"
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "bundled": true,
+                  "dev": true
+                },
+                "ini": {
+                  "version": "1.3.4",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "number-is-nan": "1.0.1"
+                  }
+                },
+                "is-typedarray": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "jodid25519": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "jsbn": "0.1.1"
+                  }
+                },
+                "jsbn": {
+                  "version": "0.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "json-schema": {
+                  "version": "0.2.3",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "json-stable-stringify": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "jsonify": "0.0.0"
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "jsonify": {
+                  "version": "0.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "jsprim": {
+                  "version": "1.4.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "assert-plus": "1.0.0",
+                    "extsprintf": "1.0.2",
+                    "json-schema": "0.2.3",
+                    "verror": "1.3.6"
+                  },
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "mime-db": {
+                  "version": "1.27.0",
+                  "bundled": true,
+                  "dev": true
+                },
+                "mime-types": {
+                  "version": "2.1.15",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "mime-db": "1.27.0"
+                  }
+                },
+                "minimatch": {
+                  "version": "3.0.4",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "brace-expansion": "1.1.7"
+                  }
+                },
+                "minimist": {
+                  "version": "0.0.8",
+                  "bundled": true,
+                  "dev": true
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "minimist": "0.0.8"
+                  }
+                },
+                "ms": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "node-pre-gyp": {
+                  "version": "0.6.39",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "detect-libc": "1.0.2",
+                    "hawk": "3.1.3",
+                    "mkdirp": "0.5.1",
+                    "nopt": "4.0.1",
+                    "npmlog": "4.1.0",
+                    "rc": "1.2.1",
+                    "request": "2.81.0",
+                    "rimraf": "2.6.1",
+                    "semver": "5.3.0",
+                    "tar": "2.2.1",
+                    "tar-pack": "3.4.0"
+                  }
+                },
+                "nopt": {
+                  "version": "4.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "abbrev": "1.1.0",
+                    "osenv": "0.1.4"
+                  }
+                },
+                "npmlog": {
+                  "version": "4.1.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "are-we-there-yet": "1.1.4",
+                    "console-control-strings": "1.1.0",
+                    "gauge": "2.7.4",
+                    "set-blocking": "2.0.0"
+                  }
+                },
+                "number-is-nan": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "dev": true
+                },
+                "oauth-sign": {
+                  "version": "0.8.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "object-assign": {
+                  "version": "4.1.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "once": {
+                  "version": "1.4.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "wrappy": "1.0.2"
+                  }
+                },
+                "os-homedir": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "os-tmpdir": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "osenv": {
+                  "version": "0.1.4",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "os-homedir": "1.0.2",
+                    "os-tmpdir": "1.0.2"
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "dev": true
+                },
+                "performance-now": {
+                  "version": "0.2.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "process-nextick-args": {
+                  "version": "1.0.7",
+                  "bundled": true,
+                  "dev": true
+                },
+                "punycode": {
+                  "version": "1.4.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "qs": {
+                  "version": "6.4.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "rc": {
+                  "version": "1.2.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "deep-extend": "0.4.2",
+                    "ini": "1.3.4",
+                    "minimist": "1.2.0",
+                    "strip-json-comments": "2.0.1"
+                  },
+                  "dependencies": {
+                    "minimist": {
+                      "version": "1.2.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "2.2.9",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "buffer-shims": "1.0.0",
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "1.0.0",
+                    "process-nextick-args": "1.0.7",
+                    "string_decoder": "1.0.1",
+                    "util-deprecate": "1.0.2"
+                  }
+                },
+                "request": {
+                  "version": "2.81.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "aws-sign2": "0.6.0",
+                    "aws4": "1.6.0",
+                    "caseless": "0.12.0",
+                    "combined-stream": "1.0.5",
+                    "extend": "3.0.1",
+                    "forever-agent": "0.6.1",
+                    "form-data": "2.1.4",
+                    "har-validator": "4.2.1",
+                    "hawk": "3.1.3",
+                    "http-signature": "1.1.1",
+                    "is-typedarray": "1.0.0",
+                    "isstream": "0.1.2",
+                    "json-stringify-safe": "5.0.1",
+                    "mime-types": "2.1.15",
+                    "oauth-sign": "0.8.2",
+                    "performance-now": "0.2.0",
+                    "qs": "6.4.0",
+                    "safe-buffer": "5.0.1",
+                    "stringstream": "0.0.5",
+                    "tough-cookie": "2.3.2",
+                    "tunnel-agent": "0.6.0",
+                    "uuid": "3.0.1"
+                  }
+                },
+                "rimraf": {
+                  "version": "2.6.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "glob": "7.1.2"
+                  }
+                },
+                "safe-buffer": {
+                  "version": "5.0.1",
+                  "bundled": true,
+                  "dev": true
+                },
+                "semver": {
+                  "version": "5.3.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "set-blocking": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "signal-exit": {
+                  "version": "3.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "hoek": "2.16.3"
+                  }
+                },
+                "sshpk": {
+                  "version": "1.13.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "asn1": "0.2.3",
+                    "assert-plus": "1.0.0",
+                    "bcrypt-pbkdf": "1.0.1",
+                    "dashdash": "1.14.1",
+                    "ecc-jsbn": "0.1.1",
+                    "getpass": "0.1.7",
+                    "jodid25519": "1.0.2",
+                    "jsbn": "0.1.1",
+                    "tweetnacl": "0.14.5"
+                  },
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                },
+                "string-width": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  }
+                },
+                "string_decoder": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "safe-buffer": "5.0.1"
+                  }
+                },
+                "stringstream": {
+                  "version": "0.0.5",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  }
+                },
+                "strip-json-comments": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "tar": {
+                  "version": "2.2.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "block-stream": "0.0.9",
+                    "fstream": "1.0.11",
+                    "inherits": "2.0.3"
+                  }
+                },
+                "tar-pack": {
+                  "version": "3.4.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "debug": "2.6.8",
+                    "fstream": "1.0.11",
+                    "fstream-ignore": "1.0.5",
+                    "once": "1.4.0",
+                    "readable-stream": "2.2.9",
+                    "rimraf": "2.6.1",
+                    "tar": "2.2.1",
+                    "uid-number": "0.0.6"
+                  }
+                },
+                "tough-cookie": {
+                  "version": "2.3.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "punycode": "1.4.1"
+                  }
+                },
+                "tunnel-agent": {
+                  "version": "0.6.0",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "safe-buffer": "5.0.1"
+                  }
+                },
+                "tweetnacl": {
+                  "version": "0.14.5",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "uid-number": {
+                  "version": "0.0.6",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true
+                },
+                "uuid": {
+                  "version": "3.0.1",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true
+                },
+                "verror": {
+                  "version": "1.3.6",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "extsprintf": "1.0.2"
+                  }
+                },
+                "wide-align": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "string-width": "1.0.2"
+                  }
+                },
+                "wrappy": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
             },
             "glob-parent": {
               "version": "2.0.0",
@@ -9866,6 +10771,13 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
+    "nan": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+      "dev": true,
+      "optional": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -17699,6 +18611,7 @@
               "requires": {
                 "anymatch": "1.3.0",
                 "async-each": "1.0.0",
+                "fsevents": "1.1.3",
                 "glob-parent": "2.0.0",
                 "inherits": "2.0.1",
                 "is-binary-path": "1.0.1",
@@ -18022,6 +18935,910 @@
                   "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.0.tgz",
                   "integrity": "sha1-tTGSJsKdmSd99jyK7gQJOqXx058=",
                   "dev": true
+                },
+                "fsevents": {
+                  "version": "1.1.3",
+                  "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+                  "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "nan": "2.8.0",
+                    "node-pre-gyp": "0.6.39"
+                  },
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "ajv": {
+                      "version": "4.11.8",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "co": "4.6.0",
+                        "json-stable-stringify": "1.0.1"
+                      }
+                    },
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "aproba": {
+                      "version": "1.1.1",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "are-we-there-yet": {
+                      "version": "1.1.4",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "delegates": "1.0.0",
+                        "readable-stream": "2.2.9"
+                      }
+                    },
+                    "asn1": {
+                      "version": "0.2.3",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "assert-plus": {
+                      "version": "0.2.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "asynckit": {
+                      "version": "0.4.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "aws-sign2": {
+                      "version": "0.6.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "aws4": {
+                      "version": "1.6.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "balanced-match": {
+                      "version": "0.4.2",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "bcrypt-pbkdf": {
+                      "version": "1.0.1",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "tweetnacl": "0.14.5"
+                      }
+                    },
+                    "block-stream": {
+                      "version": "0.0.9",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "inherits": "2.0.3"
+                      }
+                    },
+                    "boom": {
+                      "version": "2.10.1",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "hoek": "2.16.3"
+                      }
+                    },
+                    "brace-expansion": {
+                      "version": "1.1.7",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "balanced-match": "0.4.2",
+                        "concat-map": "0.0.1"
+                      }
+                    },
+                    "buffer-shims": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "caseless": {
+                      "version": "0.12.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "co": {
+                      "version": "4.6.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "code-point-at": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "combined-stream": {
+                      "version": "1.0.5",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "delayed-stream": "1.0.0"
+                      }
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "console-control-strings": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "boom": "2.10.1"
+                      }
+                    },
+                    "dashdash": {
+                      "version": "1.14.1",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "assert-plus": "1.0.0"
+                      },
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "2.6.8",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "ms": "2.0.0"
+                      }
+                    },
+                    "deep-extend": {
+                      "version": "0.4.2",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "delegates": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "detect-libc": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "0.1.1"
+                      }
+                    },
+                    "extend": {
+                      "version": "3.0.1",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "extsprintf": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "forever-agent": {
+                      "version": "0.6.1",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "form-data": {
+                      "version": "2.1.4",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.5",
+                        "mime-types": "2.1.15"
+                      }
+                    },
+                    "fs.realpath": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "fstream": {
+                      "version": "1.0.11",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "graceful-fs": "4.1.11",
+                        "inherits": "2.0.3",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.6.1"
+                      }
+                    },
+                    "fstream-ignore": {
+                      "version": "1.0.5",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "fstream": "1.0.11",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4"
+                      }
+                    },
+                    "gauge": {
+                      "version": "2.7.4",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "aproba": "1.1.1",
+                        "console-control-strings": "1.1.0",
+                        "has-unicode": "2.0.1",
+                        "object-assign": "4.1.1",
+                        "signal-exit": "3.0.2",
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wide-align": "1.1.2"
+                      }
+                    },
+                    "getpass": {
+                      "version": "0.1.7",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "assert-plus": "1.0.0"
+                      },
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "glob": {
+                      "version": "7.1.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                      }
+                    },
+                    "graceful-fs": {
+                      "version": "4.1.11",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "har-schema": {
+                      "version": "1.0.5",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "har-validator": {
+                      "version": "4.2.1",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "ajv": "4.11.8",
+                        "har-schema": "1.0.5"
+                      }
+                    },
+                    "has-unicode": {
+                      "version": "2.0.1",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "hawk": {
+                      "version": "3.1.3",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "boom": "2.10.1",
+                        "cryptiles": "2.0.5",
+                        "hoek": "2.16.3",
+                        "sntp": "1.0.9"
+                      }
+                    },
+                    "hoek": {
+                      "version": "2.16.3",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "http-signature": {
+                      "version": "1.1.1",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "assert-plus": "0.2.0",
+                        "jsprim": "1.4.0",
+                        "sshpk": "1.13.0"
+                      }
+                    },
+                    "inflight": {
+                      "version": "1.0.6",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "ini": {
+                      "version": "1.3.4",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "is-fullwidth-code-point": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "number-is-nan": "1.0.1"
+                      }
+                    },
+                    "is-typedarray": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "isstream": {
+                      "version": "0.1.2",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "jodid25519": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "0.1.1"
+                      }
+                    },
+                    "jsbn": {
+                      "version": "0.1.1",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "json-schema": {
+                      "version": "0.2.3",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "json-stable-stringify": {
+                      "version": "1.0.1",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "jsonify": "0.0.0"
+                      }
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.1",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "jsonify": {
+                      "version": "0.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "jsprim": {
+                      "version": "1.4.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "assert-plus": "1.0.0",
+                        "extsprintf": "1.0.2",
+                        "json-schema": "0.2.3",
+                        "verror": "1.3.6"
+                      },
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "mime-db": {
+                      "version": "1.27.0",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "mime-types": {
+                      "version": "2.1.15",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "mime-db": "1.27.0"
+                      }
+                    },
+                    "minimatch": {
+                      "version": "3.0.4",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "brace-expansion": "1.1.7"
+                      }
+                    },
+                    "minimist": {
+                      "version": "0.0.8",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "minimist": "0.0.8"
+                      }
+                    },
+                    "ms": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "node-pre-gyp": {
+                      "version": "0.6.39",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "detect-libc": "1.0.2",
+                        "hawk": "3.1.3",
+                        "mkdirp": "0.5.1",
+                        "nopt": "4.0.1",
+                        "npmlog": "4.1.0",
+                        "rc": "1.2.1",
+                        "request": "2.81.0",
+                        "rimraf": "2.6.1",
+                        "semver": "5.3.0",
+                        "tar": "2.2.1",
+                        "tar-pack": "3.4.0"
+                      }
+                    },
+                    "nopt": {
+                      "version": "4.0.1",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "abbrev": "1.1.0",
+                        "osenv": "0.1.4"
+                      }
+                    },
+                    "npmlog": {
+                      "version": "4.1.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "are-we-there-yet": "1.1.4",
+                        "console-control-strings": "1.1.0",
+                        "gauge": "2.7.4",
+                        "set-blocking": "2.0.0"
+                      }
+                    },
+                    "number-is-nan": {
+                      "version": "1.0.1",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "oauth-sign": {
+                      "version": "0.8.2",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "object-assign": {
+                      "version": "4.1.1",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "once": {
+                      "version": "1.4.0",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "wrappy": "1.0.2"
+                      }
+                    },
+                    "os-homedir": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "os-tmpdir": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "osenv": {
+                      "version": "0.1.4",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.1",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "performance-now": {
+                      "version": "0.2.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "punycode": {
+                      "version": "1.4.1",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "qs": {
+                      "version": "6.4.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "rc": {
+                      "version": "1.2.1",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "deep-extend": "0.4.2",
+                        "ini": "1.3.4",
+                        "minimist": "1.2.0",
+                        "strip-json-comments": "2.0.1"
+                      },
+                      "dependencies": {
+                        "minimist": {
+                          "version": "1.2.0",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "readable-stream": {
+                      "version": "2.2.9",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "buffer-shims": "1.0.0",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "1.0.1",
+                        "util-deprecate": "1.0.2"
+                      }
+                    },
+                    "request": {
+                      "version": "2.81.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "aws-sign2": "0.6.0",
+                        "aws4": "1.6.0",
+                        "caseless": "0.12.0",
+                        "combined-stream": "1.0.5",
+                        "extend": "3.0.1",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.1.4",
+                        "har-validator": "4.2.1",
+                        "hawk": "3.1.3",
+                        "http-signature": "1.1.1",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.15",
+                        "oauth-sign": "0.8.2",
+                        "performance-now": "0.2.0",
+                        "qs": "6.4.0",
+                        "safe-buffer": "5.0.1",
+                        "stringstream": "0.0.5",
+                        "tough-cookie": "2.3.2",
+                        "tunnel-agent": "0.6.0",
+                        "uuid": "3.0.1"
+                      }
+                    },
+                    "rimraf": {
+                      "version": "2.6.1",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "glob": "7.1.2"
+                      }
+                    },
+                    "safe-buffer": {
+                      "version": "5.0.1",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "semver": {
+                      "version": "5.3.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "set-blocking": {
+                      "version": "2.0.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "signal-exit": {
+                      "version": "3.0.2",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "hoek": "2.16.3"
+                      }
+                    },
+                    "sshpk": {
+                      "version": "1.13.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "asn1": "0.2.3",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.1",
+                        "dashdash": "1.14.1",
+                        "ecc-jsbn": "0.1.1",
+                        "getpass": "0.1.7",
+                        "jodid25519": "1.0.2",
+                        "jsbn": "0.1.1",
+                        "tweetnacl": "0.14.5"
+                      },
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "string-width": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                      }
+                    },
+                    "string_decoder": {
+                      "version": "1.0.1",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "safe-buffer": "5.0.1"
+                      }
+                    },
+                    "stringstream": {
+                      "version": "0.0.5",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "ansi-regex": "2.1.1"
+                      }
+                    },
+                    "strip-json-comments": {
+                      "version": "2.0.1",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "tar": {
+                      "version": "2.2.1",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "block-stream": "0.0.9",
+                        "fstream": "1.0.11",
+                        "inherits": "2.0.3"
+                      }
+                    },
+                    "tar-pack": {
+                      "version": "3.4.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "debug": "2.6.8",
+                        "fstream": "1.0.11",
+                        "fstream-ignore": "1.0.5",
+                        "once": "1.4.0",
+                        "readable-stream": "2.2.9",
+                        "rimraf": "2.6.1",
+                        "tar": "2.2.1",
+                        "uid-number": "0.0.6"
+                      }
+                    },
+                    "tough-cookie": {
+                      "version": "2.3.2",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "punycode": "1.4.1"
+                      }
+                    },
+                    "tunnel-agent": {
+                      "version": "0.6.0",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "safe-buffer": "5.0.1"
+                      }
+                    },
+                    "tweetnacl": {
+                      "version": "0.14.5",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "uid-number": {
+                      "version": "0.0.6",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "dev": true
+                    },
+                    "uuid": {
+                      "version": "3.0.1",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true
+                    },
+                    "verror": {
+                      "version": "1.3.6",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "extsprintf": "1.0.2"
+                      }
+                    },
+                    "wide-align": {
+                      "version": "1.1.2",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "string-width": "1.0.2"
+                      }
+                    },
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "dev": true
+                    }
+                  }
                 },
                 "glob-parent": {
                   "version": "2.0.0",

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -2,6 +2,9 @@
 /* global sinon, expect */
 /* eslint no-unused-expressions:0 */
 
+const nextAnimationFrame = () => new Promise(requestAnimationFrame);
+
+
 describe(`Simple Component instance`, function() {
   let el;
 
@@ -111,19 +114,18 @@ describe(`Simple Component instance`, function() {
       });
     });
 
-    it(`does not re-render if shouldUpdate() returns false`, function(done) {
+    it(`does not re-render if shouldUpdate() returns false`, async function() {
       expect(el.textContent).to.contain(`Value of foo: bar`);
-
       el.update({foo: `meow`});
-      window.requestAnimationFrame(() => {
-        expect(el.textContent).to.contain(`Value of foo: bar`); // no change
 
-        el.update({foo: `something else`});
-        window.requestAnimationFrame(() => {
-          expect(el.textContent).to.contain(`Value of foo: something else`);
-          done();
-        });
-      });
+      await nextAnimationFrame();
+
+      expect(el.textContent).to.contain(`Value of foo: bar`); // no change
+      el.update({foo: `something else`});
+
+      await nextAnimationFrame();
+
+      expect(el.textContent).to.contain(`Value of foo: something else`);
     });
   });
 

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -127,6 +127,15 @@ describe(`Simple Component instance`, function() {
 
       expect(el.textContent).to.contain(`Value of foo: something else`);
     });
+
+    it(`passes full state context to shouldUpdate()`, async function() {
+      expect(el.textContent).to.contain(`Value of baz: qux`);
+      el.update({baz: `llamas`});
+
+      await nextAnimationFrame();
+
+      expect(el.textContent).to.contain(`Value of baz: llamas`);
+    });
   });
 
   context(`when using shadow DOM`, function() {

--- a/test/browser/index.js
+++ b/test/browser/index.js
@@ -1,2 +1,4 @@
+import 'babel-polyfill';
+
 import '../fixtures/index'; // import fixtures
 import './component.js'; // import tests

--- a/test/browser/webpack.config.js
+++ b/test/browser/webpack.config.js
@@ -15,6 +15,10 @@ const webpackConfig = {
         exclude: /node_modules/,
         loader: `babel`,
         query: {
+          plugins: [
+            `syntax-async-functions`,
+            `transform-regenerator`,
+          ],
           presets: [`es2015`],
         },
       },

--- a/test/fixtures/simple-app.js
+++ b/test/fixtures/simple-app.js
@@ -5,6 +5,7 @@ export class SimpleApp extends Component {
     return {
       defaultState: {
         foo: 'bar',
+        baz: 'qux',
       },
 
       helpers: {
@@ -13,6 +14,7 @@ export class SimpleApp extends Component {
 
       template: state => h('div', {class: {foo: true}}, [
         h('p', `Value of foo: ${state.foo}`),
+        h('p', `Value of baz: ${state.baz}`),
         h('p', `Foo capitalized: ${state.$helpers.capitalize(state.foo)}`),
       ]),
     };
@@ -20,6 +22,6 @@ export class SimpleApp extends Component {
 
   shouldUpdate(state) {
     // I simply refuse to say "Value of foo: meow"
-    return state.foo !== 'meow';
+    return !!state.foo && state.foo !== 'meow';
   }
 }

--- a/test/server/component.js
+++ b/test/server/component.js
@@ -18,14 +18,14 @@ describe('Server-side component renderer', function() {
     const el = document.createElement('simple-app');
     expect(el.state).to.eql({});
     el.attachedCallback();
-    expect(el.state).to.eql({foo: 'bar'});
+    expect(el.state).to.eql({foo: 'bar', baz: 'qux'});
   });
 
   it('supports class instantiation', function() {
     const el = new SimpleApp();
     expect(el.state).to.eql({});
     el.attachedCallback();
-    expect(el.state).to.eql({foo: 'bar'});
+    expect(el.state).to.eql({foo: 'bar', baz: 'qux'});
   });
 
   it('renders a simple component', async function() {


### PR DESCRIPTION
Longer term the right thing to do is probably to split out the existing method into `shouldUpdate()` (given the update fragment to apply) and `shouldRender()` (given the entire current state), but this should fix uses of the existing API broken by https://github.com/mixpanel/panel/pull/25/files#diff-265939b2d7ffc46f04bdad9c44d75688R387

(also adds infra for async/await in browser tests, though doesn't convert most existing tests)