### PR TITLE
Webpack hmr status bar

### DIFF
--- a/hot/hmr-status-bar.js
+++ b/hot/hmr-status-bar.js
@@ -5,20 +5,20 @@
  */
 
 const webpackEventColors = {
-  ok: `39d183`, // green (connected and idle)
-  invalid: `a081ea`, // purple (compiling)
-  warnings: `dd731d`, // orange
-  errors: `e4567b`, // red
-  close: `9bacbf`, // grey (socket disconnected)
+  ok: `#39d183`, // green (connected and idle)
+  invalid: `#a081ea`, // purple (compiling)
+  warnings: `#dd731d`, // orange
+  errors: `#e4567b`, // red
+  close: `#9bacbf`, // grey (socket disconnected)
 };
 
 window.addEventListener(`message`, event => {
   const webpackPrefix = `webpack`;
-  let eventType = event.data.type;
+  const eventType = event.data.type;
   if (eventType && eventType.startsWith(webpackPrefix)) {
-    eventType = eventType.substr(webpackPrefix.length).toLowerCase();
+    const webpackEvent = eventType.substr(webpackPrefix.length).toLowerCase();
     const bodyStyle = window.document.body.style;
-    bodyStyle.borderTop = `2px solid #${webpackEventColors[eventType]}`;
+    bodyStyle.borderTop = `2px solid ${webpackEventColors[webpackEvent]}`;
   }
 });
 

--- a/hot/hmr-status-bar.js
+++ b/hot/hmr-status-bar.js
@@ -1,0 +1,24 @@
+/**
+ * Shows a thin bar at the top of the page that changes colors
+ * when webpack status changes from idle -> compiling -> error / warning
+ * Useful visual indicator in HMR mode to know when compilation finished/failed
+ */
+
+const webpackEventColors = {
+  ok: `39d183`, // green (connected and idle)
+  invalid: `a081ea`, // purple (compiling)
+  warnings: `dd731d`, // orange
+  errors: `e4567b`, // red
+  close: `9bacbf`, // grey (socket disconnected)
+};
+
+window.addEventListener(`message`, event => {
+  const webpackPrefix = `webpack`;
+  let eventType = event.data.type;
+  if (eventType && eventType.startsWith(webpackPrefix)) {
+    eventType = eventType.substr(webpackPrefix.length).toLowerCase();
+    const bodyStyle = window.document.body.style;
+    bodyStyle.borderTop = `2px solid #${webpackEventColors[eventType]}`;
+  }
+});
+

--- a/hot/hmr-status-bar.js
+++ b/hot/hmr-status-bar.js
@@ -1,7 +1,7 @@
 /**
  * Shows a thin bar at the top of the page that changes colors
  * when webpack status changes from idle -> compiling -> error / warning
- * Useful visual indicator in HMR mode to know when compilation finished/failed
+ * A nice unobtrusive webpack status notification system
  */
 
 const webpackEventColors = {


### PR DESCRIPTION
```
/**
 * Shows a thin bar at the top of the page that changes colors
 * when webpack status changes from idle -> compiling -> error / warning
 * A nice unobtrusive webpack status notification system
 */
```

Connected & idle (green)

![image](https://user-images.githubusercontent.com/1018196/35667009-ee9425fe-06e0-11e8-929f-f7d50975641d.png)

Compiling (purple)

![image](https://user-images.githubusercontent.com/1018196/35667164-760e7bb0-06e1-11e8-8ac1-2d896e982f53.png)

Disconnected (grey) - > probably webpack-server is killed or internet connection lost

![image](https://user-images.githubusercontent.com/1018196/35667071-1df3cd0e-06e1-11e8-817f-fcb9a89340de.png)

Warnings (orange): Check for warnings but changes applied

![image](https://user-images.githubusercontent.com/1018196/35667315-0613371e-06e2-11e8-8bb8-216b0e79e5ff.png)

Errors (red): Check for compiler errors, changes NOT applied

![image](https://user-images.githubusercontent.com/1018196/35667379-46b51b7a-06e2-11e8-82d0-4905358b9649.png)

