### PR TITLE
Add pre- and post-update hooks

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -361,6 +361,14 @@ class Component extends WebComponent {
     return this._rendered || EMPTY_DIV;
   }
 
+  // run a user-defined hook with the given params, if configured
+  _runHook(hookName, ...params) {
+    const hook = (this.getConfig(`hooks`) || {})[hookName];
+    if (hook) {
+      hook(...params);
+    }
+  }
+
   _stateFromAttributes() {
     let state = {};
 
@@ -411,10 +419,7 @@ class Component extends WebComponent {
       return;
     }
 
-    const {preUpdate, postUpdate} = this.getConfig(`hooks`) || {};
-    if (preUpdate) {
-      preUpdate();
-    }
+    this._runHook(`preUpdate`, stateUpdate);
 
     const {store, cascade} = options;
     Object.assign(this[store], stateUpdate);
@@ -430,9 +435,7 @@ class Component extends WebComponent {
       }
     }
 
-    if (postUpdate) {
-      postUpdate();
-    }
+    this._runHook(`postUpdate`, stateUpdate);
   }
 }
 

--- a/lib/component.js
+++ b/lib/component.js
@@ -362,10 +362,22 @@ class Component extends WebComponent {
   }
 
   // run a user-defined hook with the given params, if configured
-  _runHook(hookName, ...params) {
+  // cascade down tree hierarchy if option is set
+  runHook(hookName, options, ...params) {
+    if (!this.initialized) {
+      return;
+    }
+
     const hook = (this.getConfig(`hooks`) || {})[hookName];
     if (hook) {
       hook(...params);
+    }
+    if (options.cascade) {
+      for (let child of this.$panelChildren) {
+        if (options.exclude !== child) {
+          child.runHook(hookName, options, ...params);
+        }
+      }
     }
   }
 
@@ -400,12 +412,26 @@ class Component extends WebComponent {
 
       // update DOM, router, descendants etc.
       const updateHash = '$fragment' in stateUpdate && stateUpdate.$fragment !== this[store].$fragment;
-      this.updateSelfAndChildren(stateUpdate, {cascade, store});
-      if (cascade && !this.isPanelRoot) {
-        this.$panelRoot.updateSelfAndChildren(stateUpdate, {exclude: this, cascade, store});
+      const cascadeFromRoot = cascade && !this.isPanelRoot;
+      const updateOptions = {cascade, store};
+      const rootOptions = {exclude: this, cascade, store};
+
+      this.runHook(`preUpdate`, updateOptions, stateUpdate);
+      if (cascadeFromRoot) {
+        this.$panelRoot.runHook(`preUpdate`, rootOptions, stateUpdate);
+      }
+
+      this.updateSelfAndChildren(stateUpdate, updateOptions);
+      if (cascadeFromRoot) {
+        this.$panelRoot.updateSelfAndChildren(stateUpdate, rootOptions);
       }
       if (updateHash) {
         this.router.replaceHash(this[store].$fragment);
+      }
+
+      this.runHook(`postUpdate`, updateOptions, stateUpdate);
+      if (cascadeFromRoot) {
+        this.$panelRoot.runHook(`postUpdate`, rootOptions, stateUpdate);
       }
     }
   }
@@ -418,8 +444,6 @@ class Component extends WebComponent {
     if (!this.initialized) {
       return;
     }
-
-    this._runHook(`preUpdate`, stateUpdate);
 
     const {store, cascade} = options;
     Object.assign(this[store], stateUpdate);
@@ -434,8 +458,6 @@ class Component extends WebComponent {
         }
       }
     }
-
-    this._runHook(`postUpdate`, stateUpdate);
   }
 }
 

--- a/lib/component.js
+++ b/lib/component.js
@@ -46,6 +46,9 @@ class Component extends WebComponent {
    * @property {object} [appState={}] - (app root component only) state object to share with nested descendant components;
    * if not set, root component shares entire state object with all descendants
    * @property {object} [defaultState={}] - default entries for component state
+   * @property {object} [hooks={}] - extra rendering/lifecycle callbacks
+   * @property {function} [hooks.preUpdate] - called before an update is applied
+   * @property {function} [hooks.postUpdate] - called after an update is applied
    * @property {boolean} [updateSync=false] - whether to apply updates to DOM
    * immediately, instead of batching to one update per frame
    * @property {boolean} [useShadowDom=false] - whether to use Shadow DOM
@@ -408,6 +411,11 @@ class Component extends WebComponent {
       return;
     }
 
+    const {preUpdate, postUpdate} = this.getConfig(`hooks`) || {};
+    if (preUpdate) {
+      preUpdate();
+    }
+
     const {store, cascade} = options;
     Object.assign(this[store], stateUpdate);
     if (store !== `state` || this.shouldUpdate(this[store])) {
@@ -420,6 +428,10 @@ class Component extends WebComponent {
           }
         }
       }
+    }
+
+    if (postUpdate) {
+      postUpdate();
     }
   }
 }

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -137,13 +137,10 @@ describe(`Simple Component instance`, function() {
       expect(el.textContent).to.contain(`Value of baz: llamas`);
     });
 
-    it(`fires update hooks`, async function() {
+    it(`fires update hooks`, function() {
       expect(el.didPre).to.be.undefined;
       expect(el.didPost).to.be.undefined;
       el.update({baz: `llamas`});
-
-      await nextAnimationFrame();
-
       expect(el.didPre).to.be.ok;
       expect(el.didPost).to.be.ok;
     });
@@ -321,13 +318,10 @@ describe(`Nested Component instance`, function() {
       });
     });
 
-    it(`fires parent update hooks when child updates`, async function() {
+    it(`fires parent update hooks when child updates`, function() {
       expect(el.didNestedPre).to.be.undefined;
       expect(el.didNestedPost).to.be.undefined;
       childEl.update({title: `new title`});
-
-      await nextAnimationFrame();
-
       expect(el.didNestedPre).to.be.ok;
       expect(el.didNestedPost).to.be.ok;
     });

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -320,6 +320,17 @@ describe(`Nested Component instance`, function() {
         done();
       });
     });
+
+    it(`fires parent update hooks when child updates`, async function() {
+      expect(el.didNestedPre).to.be.undefined;
+      expect(el.didNestedPost).to.be.undefined;
+      childEl.update({title: `new title`});
+
+      await nextAnimationFrame();
+
+      expect(el.didNestedPre).to.be.ok;
+      expect(el.didNestedPost).to.be.ok;
+    });
   });
 });
 

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -136,6 +136,17 @@ describe(`Simple Component instance`, function() {
 
       expect(el.textContent).to.contain(`Value of baz: llamas`);
     });
+
+    it(`fires update hooks`, async function() {
+      expect(el.didPre).to.be.undefined;
+      expect(el.didPost).to.be.undefined;
+      el.update({baz: `llamas`});
+
+      await nextAnimationFrame();
+
+      expect(el.didPre).to.be.ok;
+      expect(el.didPost).to.be.ok;
+    });
   });
 
   context(`when using shadow DOM`, function() {

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -138,11 +138,11 @@ describe(`Simple Component instance`, function() {
     });
 
     it(`fires update hooks`, function() {
-      expect(el.didPre).to.be.undefined;
-      expect(el.didPost).to.be.undefined;
-      el.update({baz: `llamas`});
-      expect(el.didPre).to.be.ok;
-      expect(el.didPost).to.be.ok;
+      expect(el.preFoo).to.be.undefined;
+      expect(el.postFoo).to.be.undefined;
+      el.update({foo: `llamas`});
+      expect(el.preFoo).to.equal(`bar`);
+      expect(el.postFoo).to.equal(`llamas`);
     });
   });
 

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -319,11 +319,11 @@ describe(`Nested Component instance`, function() {
     });
 
     it(`fires parent update hooks when child updates`, function() {
-      expect(el.didNestedPre).to.be.undefined;
-      expect(el.didNestedPost).to.be.undefined;
+      expect(el.nestedPreTitle).to.be.undefined;
+      expect(el.nestedPostTitle).to.be.undefined;
       childEl.update({title: `new title`});
-      expect(el.didNestedPre).to.be.ok;
-      expect(el.didNestedPost).to.be.ok;
+      expect(el.nestedPreTitle).to.equal(`test`);
+      expect(el.nestedPostTitle).to.equal(`new title`);
     });
   });
 });

--- a/test/fixtures/nested-app.js
+++ b/test/fixtures/nested-app.js
@@ -8,8 +8,8 @@ export class NestedApp extends Component {
       },
 
       hooks: {
-        preUpdate: () => this.didNestedPre = true,
-        postUpdate: () => this.didNestedPost = true,
+        preUpdate: () => this.nestedPreTitle = this.state.title,
+        postUpdate: () => this.nestedPostTitle = this.state.title,
       },
 
       template: state => h('div', {class: {'nested-foo': true}}, [

--- a/test/fixtures/nested-app.js
+++ b/test/fixtures/nested-app.js
@@ -7,6 +7,11 @@ export class NestedApp extends Component {
         title: 'test',
       },
 
+      hooks: {
+        preUpdate: () => this.didNestedPre = true,
+        postUpdate: () => this.didNestedPost = true,
+      },
+
       template: state => h('div', {class: {'nested-foo': true}}, [
         h('h1', `Nested app: ${state.title}`),
         this.child('nested-child', {attrs: {'state-animal': 'llama'}}),

--- a/test/fixtures/simple-app.js
+++ b/test/fixtures/simple-app.js
@@ -12,6 +12,11 @@ export class SimpleApp extends Component {
         capitalize: s => s[0].toUpperCase() + s.slice(1),
       },
 
+      hooks: {
+        preUpdate: () => this.didPre = true,
+        postUpdate: () => this.didPost = true,
+      },
+
       template: state => h('div', {class: {foo: true}}, [
         h('p', `Value of foo: ${state.foo}`),
         h('p', `Value of baz: ${state.baz}`),

--- a/test/fixtures/simple-app.js
+++ b/test/fixtures/simple-app.js
@@ -13,8 +13,8 @@ export class SimpleApp extends Component {
       },
 
       hooks: {
-        preUpdate: () => this.didPre = true,
-        postUpdate: () => this.didPost = true,
+        preUpdate: () => this.preFoo = this.state.foo,
+        postUpdate: () => this.postFoo = this.state.foo,
       },
 
       template: state => h('div', {class: {foo: true}}, [


### PR DESCRIPTION
It used to be that you could simply override a Component's `update()` method to wrap update behavior (for instance, for automatically persisting state to localStorage), but as of https://github.com/mixpanel/panel/pull/25 that no longer works with cascading updates, because the main `update()` method only runs on the component making the initial update call, while any other linked components only get updated via internal methods.

This branch addresses the issue by offering callback hooks `preUpdate` and `postUpdate`:
```js
get config() {
  return {
    // ...
    hooks: {
      postUpdate: () => persistLatestStuff(this.state),
    },
  };
}
```

We could alternatively make sure that cascading updates actually call `update()` on each affected component in the tree (which would be a bigger refactor), but IMO that's not really obvious behavior, and this is a little more explicit.