### PR TITLE
_syncAttrs on constructor and connectedCallback

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -203,7 +203,7 @@ class Component extends WebComponent {
     this.panelID = cuid();
 
     this.attrs = {};
-    this._syncAttrs();
+    this._syncAttrs(); // constructor sync ensures default properties are present on this.attrs
 
     this._config = Object.assign({}, {
       css: ``,

--- a/lib/component.js
+++ b/lib/component.js
@@ -292,7 +292,6 @@ class Component extends WebComponent {
     );
 
     Object.assign(this.state, newState);
-    this._syncAttrs();
 
     if (Object.keys(this.getConfig(`routes`)).length) {
       this.router = new Router(this, {historyMethod: this.historyMethod});

--- a/lib/component.js
+++ b/lib/component.js
@@ -201,6 +201,10 @@ class Component extends WebComponent {
     super();
 
     this.panelID = cuid();
+
+    this.attrs = {};
+    this._syncAttrs();
+
     this._config = Object.assign({}, {
       css: ``,
       helpers: {},
@@ -214,8 +218,8 @@ class Component extends WebComponent {
     // appState and isStateShared of child components will be overwritten by parent/root
     // when the component is connected to the hierarchy
     this.state = {};
-    this.attrs = {};
     this.appState = this.getConfig(`appState`);
+
     if (!this.appState) {
       this.appState = {};
       this.isStateShared = true;
@@ -288,7 +292,7 @@ class Component extends WebComponent {
     );
 
     Object.assign(this.state, newState);
-    Object.keys(this.constructor.attrsSchema).forEach(attr => this._updateAttr(attr));
+    this._syncAttrs();
 
     if (Object.keys(this.getConfig(`routes`)).length) {
       this.router = new Router(this, {historyMethod: this.historyMethod});
@@ -418,6 +422,16 @@ class Component extends WebComponent {
     }
 
     return state;
+  }
+
+  /**
+   * Syncs element attributes defined in attrsSchema with this.attrs
+   */
+  _syncAttrs() {
+    for (const attr of Object.keys(this.constructor.attrsSchema)) {
+      this._updateAttr(attr);
+    }
+    return this.attrs;
   }
 
   /**

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -274,7 +274,7 @@ describe(`Simple Component instance with attrsSchema`, function() {
       'number-attr': 0,
       'json-attr': null,
     });
-    // _config is initialised in construtor. defaultState should be able to access el.attrs
+    // _config is initialised in constructor. defaultState should be able to access el.attrs
     expect(el._config.defaultState.str).to.equal(`placeholder`);
   });
 });

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -265,6 +265,18 @@ describe(`Simple Component instance with attrsSchema`, function() {
       `json-attr`,
     ]);
   });
+
+  it(`has default attrs present after createElement`, function() {
+    el = document.createElement(`attrs-reflection-app`);
+    expect(el.attrs).to.deep.equal({
+      'str-attr': `placeholder`,
+      'bool-attr': false,
+      'number-attr': 0,
+      'json-attr': null,
+    });
+    // _config is initialised in construtor. defaultState should be able to access el.attrs
+    expect(el._config.defaultState.str).to.equal(`placeholder`);
+  });
 });
 
 describe(`Nested Component instance`, function() {

--- a/test/fixtures/attrs-reflection-app.js
+++ b/test/fixtures/attrs-reflection-app.js
@@ -15,7 +15,6 @@ export class AttrsReflectionApp extends Component {
         Object.entries(scope.$attrs).map(([attr, val]) => h(`p`, `${attr}: ${JSON.stringify(val)}`)),
       ),
       defaultState: {
-        // get config is called in constructor(), this.attrs should be accessible
         str: this.attrs[`str-attr`],
       },
     };

--- a/test/fixtures/attrs-reflection-app.js
+++ b/test/fixtures/attrs-reflection-app.js
@@ -14,6 +14,10 @@ export class AttrsReflectionApp extends Component {
       template: scope => h(`div`, {class: {'attrs-reflection-app': true}},
         Object.entries(scope.$attrs).map(([attr, val]) => h(`p`, `${attr}: ${JSON.stringify(val)}`)),
       ),
+      defaultState: {
+        // get config is called in constructor(), this.attrs should be accessible
+        str: this.attrs[`str-attr`],
+      },
     };
   }
 }

--- a/test/server/component.js
+++ b/test/server/component.js
@@ -178,8 +178,7 @@ describe(`Server-side component renderer`, function() {
   });
 
   it(`throws error if there is a malformed attrsSchema type`, function() {
-    const el = new BadAttrsSchemaApp();
-    expect(() => el.connectedCallback()).to.throw(
+    expect(() => new BadAttrsSchemaApp()).to.throw(
       `Unknown type: bool for attr: bad-attr in attrsSchema. Only (string | boolean | number | json) supported.`
     );
   });


### PR DESCRIPTION
It is possible to access this.attrs before calling super.connectedCallback or sometimes in defaultState. This also adds a this._syncAttrs helper