### PR TITLE
fix deps and drop node 6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,11 +1,3 @@
 {
-  "presets": ["es2015"],
-  "env": {
-    "test": {
-      "plugins": [
-        "syntax-async-functions",
-        "transform-regenerator"
-      ]
-    }
-  }
+  "presets": ["es2015"]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - '8'
-  - '6.9'
 before_script:
   - npm run build
   - npm run build-test

--- a/package-lock.json
+++ b/package-lock.json
@@ -2351,7 +2351,8 @@
         "jsbn": {
           "version": "0.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
@@ -2769,7 +2770,8 @@
         "tweetnacl": {
           "version": "0.14.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "uid-number": {
           "version": "0.0.6",
@@ -4403,9 +4405,9 @@
       }
     },
     "snabbdom": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/snabbdom/-/snabbdom-0.6.1.tgz",
-      "integrity": "sha1-sAb7lD3CcQshK/VkCq9XBMFSP5o="
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/snabbdom/-/snabbdom-0.6.2.tgz",
+      "integrity": "sha1-ppra8iUAM2yhxYqBsa6coBgD154="
     },
     "snabbdom-delayed-class": {
       "version": "0.1.1",
@@ -4761,6 +4763,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.1.tgz",
+      "integrity": "sha512-h6pM2f/GDchCFlldnriOhs1QHuwbnmj6/v7499eMHqPeW4V2G0elua2eIc2nu8v2NdHV0Gm+tzX83Hr6nUFjQA==",
       "dev": true
     },
     "underscore": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test-browser-local": "wct --plugin local test/browser/index.html",
     "test-browser-p": "wct --plugin local --persistent test/browser/index.html",
     "test-browser-sauce": "wct --plugin sauce test/browser/index.html",
-    "test-server": "NODE_ENV=test mocha --require babel-core/register --require babel-polyfill test/server",
+    "test-server": "NODE_ENV=test mocha --require babel-core/register test/server",
     "ts-check": "tsc",
     "tslint": "tslint -c tslint.json -t stylish 'lib/index.d.ts'"
   },


### PR DESCRIPTION
[Master is erroring](https://travis-ci.org/mixpanel/panel/jobs/428439091) because package-lock doesn't match package.json.
```
$ npm ci
npm ERR! cipm can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
```
Also dropping Node 6 support for build steps/SSR. Can use async/await without transpilation, will drop remaining ES2015 transpilation for server-side envs later (except `import`).