### PR TITLE
Improve template error reporting for Firefox

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -384,7 +384,7 @@ class Component extends WebComponent {
           $attrs: this.attrs,
         }));
       } catch (e) {
-        this.logError(`Error while rendering ${this.toString()}`, this, e.stack);
+        this.logError(`Error while rendering ${this.toString()}`, this, `\n`, e);
       }
     }
     return this._rendered || EMPTY_DIV;


### PR DESCRIPTION
Minor improvement on template error reporting:

After:
![image](https://user-images.githubusercontent.com/965112/51152966-1ebaee80-1823-11e9-8f44-c006b9b765c4.png)

Before:
![image](https://user-images.githubusercontent.com/965112/51152990-37c39f80-1823-11e9-82f5-f074c4e2e3ad.png)
