### PR TITLE
Router improvements

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -95,7 +95,8 @@ export default class Router {
     console.error(`No route found matching #${fragment}`);
   }
 
-  replaceHash(fragment) {
+  replaceHash(fragment, {historyMethod=null}={}) {
+    historyMethod = historyMethod || this.historyMethod;
     fragment = stripHash(fragment);
     const currHash = stripHash(this.window.location.hash);
 
@@ -103,7 +104,7 @@ export default class Router {
     // written to url, making `#bar baz` and `#bar%20baz` effectively the same.
     // This can result in hash update loops if the client passes in decoded hash.
     if (decodeURIComponent(fragment) !== decodeURIComponent(currHash)) {
-      this.window.history[this.historyMethod](null, null, `#${fragment}`);
+      this.window.history[historyMethod](null, null, `#${fragment}`);
     }
   }
 }

--- a/lib/router.js
+++ b/lib/router.js
@@ -97,7 +97,12 @@ export default class Router {
 
   replaceHash(fragment) {
     fragment = stripHash(fragment);
-    if (fragment !== stripHash(this.window.location.hash)) {
+    const currHash = stripHash(this.window.location.hash);
+
+    // decodeURIComponent since hash fragments are encoded while being
+    // written to url, making `#bar baz` and `#bar%20baz` effectively the same.
+    // This can result in hash update loops if the client passes in decoded hash.
+    if (decodeURIComponent(fragment) !== decodeURIComponent(currHash)) {
       this.window.history[this.historyMethod](null, null, `#${fragment}`);
     }
   }

--- a/lib/router.js
+++ b/lib/router.js
@@ -2,6 +2,13 @@ function stripHash(fragment) {
   return fragment.replace(/^#*/, ``);
 }
 
+function decodedFragmentsEqual(currFragment, newFragment) {
+  // decodeURIComponent since hash fragments are encoded while being
+  // written to url, making `#bar baz` and `#bar%20baz` effectively the same.
+  // This can result in hash update loops if the client passes in decoded hash.
+  return decodeURIComponent(currFragment) === decodeURIComponent(newFragment);
+}
+
 // just the necessary bits of Backbone router+history
 export default class Router {
   constructor(app, options={}) {
@@ -59,7 +66,10 @@ export default class Router {
 
   navigate(fragment, stateUpdate={}) {
     fragment = stripHash(fragment);
-    if (fragment === this.app.state.$fragment && !Object.keys(stateUpdate).length) {
+    if (
+      decodedFragmentsEqual(this.app.state.$fragment, fragment) &&
+      !Object.keys(stateUpdate).length
+    ) {
       return;
     }
 
@@ -98,12 +108,7 @@ export default class Router {
   replaceHash(fragment, {historyMethod=null}={}) {
     historyMethod = historyMethod || this.historyMethod;
     fragment = stripHash(fragment);
-    const currHash = stripHash(this.window.location.hash);
-
-    // decodeURIComponent since hash fragments are encoded while being
-    // written to url, making `#bar baz` and `#bar%20baz` effectively the same.
-    // This can result in hash update loops if the client passes in decoded hash.
-    if (decodeURIComponent(fragment) !== decodeURIComponent(currHash)) {
+    if (!decodedFragmentsEqual(stripHash(this.window.location.hash), fragment)) {
       this.window.history[historyMethod](null, null, `#${fragment}`);
     }
   }

--- a/test/browser/router.js
+++ b/test/browser/router.js
@@ -114,6 +114,25 @@ describe(`Router`, function() {
       expect(window.location.hash).to.equal(`#foo`);
     });
 
+    it(`does not update the URL if hash is the same`, function() {
+      const historyLength = window.history.length;
+
+      this.routerApp.router.navigate(`foo`);
+      expect(window.history.length).to.equal(historyLength + 1);
+      this.routerApp.router.navigate(`foo`);
+      expect(window.history.length).to.equal(historyLength + 1);
+
+      // ensure window.location.hash is properly URI-decoded for comparison,
+      // otherwise `widget/bar baz` !== `widget/bar%20baz` may be compared
+      // resulting in possible circular redirect loop
+      this.routerApp.router.navigate(`widget/bar baz`);
+      expect(window.history.length).to.equal(historyLength + 2);
+      this.routerApp.router.navigate(`widget/bar baz`);
+      expect(window.history.length).to.equal(historyLength + 2);
+      this.routerApp.router.navigate(`widget/bar%20baz`);
+      expect(window.history.length).to.equal(historyLength + 2);
+    });
+
     it(`supports passing state updates to the route handler`, async function() {
       this.routerApp.router.navigate(`widget/5`, {additionalText: ` and more!`});
       await retryable(() => expect(this.routerApp.textContent).to.equal(`Widget 5 and more!`));

--- a/test/browser/router.js
+++ b/test/browser/router.js
@@ -130,4 +130,31 @@ describe(`Router`, function() {
       expect(this.routerApp.textContent).to.equal(`Number: 42`);
     });
   });
+
+  describe(`replaceHash()`, function() {
+    it(`updates the URL`, function() {
+      expect(window.location.hash).not.to.equal(`#foo`);
+      this.routerApp.router.replaceHash(`foo`);
+      expect(window.location.hash).to.equal(`#foo`);
+    });
+
+    it(`does not update the URL if hash is the same`, function() {
+      const historyLength = window.history.length;
+
+      this.routerApp.router.replaceHash(`foo`);
+      expect(window.history.length).to.equal(historyLength + 1);
+      this.routerApp.router.replaceHash(`foo`);
+      expect(window.history.length).to.equal(historyLength + 1);
+
+      // ensure window.location.hash is properly URI-decoded for comparison,
+      // otherwise `widget/bar baz` !== `widget/bar%20baz` may be compared
+      // resulting in possible circular redirect loop
+      this.routerApp.router.replaceHash(`widget/bar baz`);
+      expect(window.history.length).to.equal(historyLength + 2);
+      this.routerApp.router.replaceHash(`widget/bar baz`);
+      expect(window.history.length).to.equal(historyLength + 2);
+      this.routerApp.router.replaceHash(`widget/bar%20baz`);
+      expect(window.history.length).to.equal(historyLength + 2);
+    });
+  });
 });

--- a/test/browser/router.js
+++ b/test/browser/router.js
@@ -156,5 +156,23 @@ describe(`Router`, function() {
       this.routerApp.router.replaceHash(`widget/bar%20baz`);
       expect(window.history.length).to.equal(historyLength + 2);
     });
+
+    it(`uses pushState by default and adds a history entry`, function() {
+      const historyLength = window.history.length;
+
+      this.routerApp.router.replaceHash(`foo`);
+      expect(window.history.length).to.equal(historyLength + 1);
+      this.routerApp.router.replaceHash(`widget/bar baz`);
+      expect(window.history.length).to.equal(historyLength + 2);
+    });
+
+    it(`can use replaceState to avoid adding a history entry`, function() {
+      const historyLength = window.history.length;
+
+      this.routerApp.router.replaceHash(`foo`, {historyMethod: `replaceState`});
+      expect(window.history.length).to.equal(historyLength);
+      this.routerApp.router.replaceHash(`widget/bar baz`, {historyMethod: `replaceState`});
+      expect(window.history.length).to.equal(historyLength);
+    });
   });
 });


### PR DESCRIPTION
1) Fixes a bug where hash is not decoded before comparison with fragment to decide whether update is necessary in `replaceHash`; this can result in circular hash update loop, see repro scenario.
2) Allows passing `{historyMethod: 'replaceState'}` to `replaceHash` so that you can make a singular  hash update from the client without adding a history entry if desired. My use case is lexicon, where currently nav to `report/123/lexicon` redirects to `report/123/lexicon#schema` (the hash is sanitized to match the default "subreport") and if the user now clicks back, they go back to `report/123/lexicon` instead of their previous report. This could be done by directly calling `window.history.replaceState` but doing through the panel router keeps code consistent and gives us the "has fragment changed?" check.

Repro for (1): check out `c7b2c515aad` in analytics, run lexicon in standalone mode. Nav to http://localhost:8088/iron/apps/lexicon/compiled/?feature-data_schema=true&project_id=4#transformations/events/[AI]%20Bookmark%20Retrieved. You should see
```
router.js:151 Uncaught RangeError: Maximum call stack size exceeded
    at router.js:126
    at Router.navigate (router.js:134)
    at Router.navigateToHash (router.js:66)
    at History.window.history.(:8088/iron/apps/lexicon/compiled/anonymous function) [as pushState] (http://localhost:8088/iron/apps/lexicon/compiled/lexicon.bundle.js:36858:15)
    at Router.replaceHash (router.js:163)
    at HTMLElement.index (index.js:118)
    at router.js:126
    at Router.navigate (router.js:134)
    at Router.navigateToHash (router.js:66)
    at History.window.history.(:8088/iron/apps/lexicon/compiled/anonymous function) [as pushState] (http://localhost:8088/iron/apps/lexicon/compiled/lexicon.bundle.js:36858:15)
```

<img width="1680" alt="Screen Shot 2019-03-20 at 6 54 21 PM" src="https://user-images.githubusercontent.com/299587/54772785-5e0c0f80-4bc5-11e9-8600-dec3ce960f1a.png">
