### PR TITLE
render async on Promise rather than requestAnimationFrame

### DIFF
--- a/lib/dom-patcher.js
+++ b/lib/dom-patcher.js
@@ -59,7 +59,13 @@ export class DOMPatcher {
       case `async`:
         if (!this.pending) {
           this.pending = true;
-          requestAnimationFrame(() => this.render());
+          // both Promise and requestAnimationFrame are async
+          // Promise is a microtask and gets called as soon as current call stack is empty
+          // requestAnimationFrame is about ~16ms delay and gets called after a frame is rendered
+          // waiting for requestAnimationFrame means browser does an unnecessary layout and paint.
+          // Promise keeps it async, but only a single layout and paint happens
+          // after all nested components have updated
+          new Promise(resolve => resolve()).then(() => this.render());
         }
         break;
       case `sync`:


### PR DESCRIPTION
Render on promise completion rather than requestAnimationFrame. This keeps update async but avoids unnecessary layouts and paints

![image](https://user-images.githubusercontent.com/1018196/55193323-dba2c300-5163-11e9-9577-bbed760ada6f.png)

Single render at the end: 
![image](https://user-images.githubusercontent.com/1018196/55193365-f9702800-5163-11e9-8ff8-11041d020cfd.png)


This is a proof of concept