### PR TITLE
validate this.attrs[attr] access via ES6 Proxy

### DIFF
--- a/devtools/devtools.js
+++ b/devtools/devtools.js
@@ -41,8 +41,8 @@ function getPanelElementState() {
         debugInfo.appState = panelElem.appState;
       }
 
-      if (panelElem.attrs && Object.keys(panelElem.attrs).length) {
-        debugInfo.attrs = panelElem.attrs;
+      if (panelElem._attrs && Object.keys(panelElem._attrs).length) {
+        debugInfo.attrs = panelElem._attrs;
         debugInfo.attrsSchema = panelElem.constructor.attrsSchema;
       }
 

--- a/lib/component.js
+++ b/lib/component.js
@@ -202,8 +202,21 @@ class Component extends WebComponent {
 
     this.panelID = cuid();
 
-    this.attrs = {};
+    this._attrs = {};
     this._syncAttrs(); // constructor sync ensures default properties are present on this.attrs
+    this.attrs = new Proxy(this._attrs, {
+      get(attrs, attr) {
+        if (attr in attrs) {
+          return attrs[attr];
+        } else {
+          throw new TypeError(`'${attr}' not defined in attrSchema`);
+        }
+      },
+      set() {
+        throw new TypeError(`attrs is readonly`);
+      },
+    });
+
 
     this._config = Object.assign({}, {
       css: ``,
@@ -505,7 +518,7 @@ class Component extends WebComponent {
         attrValue = this.getJSONAttribute(attr);
       }
 
-      this.attrs[attr] = attrValue;
+      this._attrs[attr] = attrValue;
     }
   }
 

--- a/lib/component.js
+++ b/lib/component.js
@@ -208,12 +208,11 @@ class Component extends WebComponent {
     if (typeof Proxy !== `undefined`) {
       this.attrs = new Proxy(this._attrs, {
         get(attrs, attr) {
-          // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON()_behavior
-          if (attr === `toJSON`) { // support JSON.stringify(this.attrs)
-            return () => attrs;
-          }
-          else if (attr in attrs) {
+          if (attr in attrs) {
             return attrs[attr];
+          } else if (attr === `toJSON`) { // support JSON.stringify(this.attrs)
+            // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON()_behavior
+            return () => attrs;
           } else {
             throw new Error(`attr '${attr}' is not defined in attrSchema`);
           }

--- a/lib/component.js
+++ b/lib/component.js
@@ -490,7 +490,7 @@ class Component extends WebComponent {
 
       this._attrsSchema[attr] = attrSchemaObj;
       this._updateAttr(attr);
-      // updated at end so doesn't warn on initial sync
+      // updated at end so we don't console.warn on initial sync
       attrSchemaObj.deprecatedMsg = attrSchema.deprecatedMsg;
     }
 

--- a/lib/component.js
+++ b/lib/component.js
@@ -204,22 +204,28 @@ class Component extends WebComponent {
 
     this._attrs = {};
     this._syncAttrs(); // constructor sync ensures default properties are present on this.attrs
-    this.attrs = new Proxy(this._attrs, {
-      get(attrs, attr) {
-        // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON()_behavior
-        if (attr === `toJSON`) { // support JSON.stringify(this.attrs)
-          return () => attrs;
-        }
-        else if (attr in attrs) {
-          return attrs[attr];
-        } else {
-          throw new Error(`attr '${attr}' is not defined in attrSchema`);
-        }
-      },
-      set() {
-        throw new Error(`attrs is readonly`);
-      },
-    });
+
+    if (typeof Proxy !== `undefined`) {
+      this.attrs = new Proxy(this._attrs, {
+        get(attrs, attr) {
+          // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON()_behavior
+          if (attr === `toJSON`) { // support JSON.stringify(this.attrs)
+            return () => attrs;
+          }
+          else if (attr in attrs) {
+            return attrs[attr];
+          } else {
+            throw new Error(`attr '${attr}' is not defined in attrSchema`);
+          }
+        },
+        set() {
+          throw new Error(`attrs is readonly`);
+        },
+      });
+    } else {
+      // fallback to normal object for old browsers that don't implement Proxy
+      this.attrs = this._attrs;
+    }
 
 
     this._config = Object.assign({}, {

--- a/lib/component.js
+++ b/lib/component.js
@@ -206,14 +206,18 @@ class Component extends WebComponent {
     this._syncAttrs(); // constructor sync ensures default properties are present on this.attrs
     this.attrs = new Proxy(this._attrs, {
       get(attrs, attr) {
-        if (attr in attrs) {
+        // see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON()_behavior
+        if (attr === `toJSON`) { // support JSON.stringify(this.attrs)
+          return () => attrs;
+        }
+        else if (attr in attrs) {
           return attrs[attr];
         } else {
-          throw new TypeError(`'${attr}' not defined in attrSchema`);
+          throw new Error(`attr '${attr}' is not defined in attrSchema`);
         }
       },
       set() {
-        throw new TypeError(`attrs is readonly`);
+        throw new Error(`attrs is readonly`);
       },
     });
 
@@ -482,6 +486,8 @@ class Component extends WebComponent {
 
       this._attrsSchema[attr] = attrSchemaObj;
       this._updateAttr(attr);
+      // updated at end so doesn't warn on initial sync
+      attrSchemaObj.deprecatedMsg = attrSchema.deprecatedMsg;
     }
 
     return this.attrs;
@@ -519,6 +525,10 @@ class Component extends WebComponent {
       }
 
       this._attrs[attr] = attrValue;
+
+      if (attrSchema.deprecatedMsg) {
+        console.warn(`attr '${attr}' is deprecated. ${attrSchema.deprecatedMsg}`);
+      }
     }
   }
 

--- a/lib/component.js
+++ b/lib/component.js
@@ -226,7 +226,6 @@ class Component extends WebComponent {
       this.attrs = this._attrs;
     }
 
-
     this._config = Object.assign({}, {
       css: ``,
       helpers: {},

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -122,6 +122,9 @@ export interface AttrSchema {
 
   /** Possible values of an attribute. e.g ['primary', 'secondary'] */
   enum?: Array<string>;
+
+  /** When attr is set, console.warn that attr is deprecated e.g 'use xyz instead' */
+  deprecatedMsg?: string;
 }
 
 type ConfigOptions<State, AppState> = Component.ConfigOptions<State, AppState>;

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -213,12 +213,12 @@ describe(`Simple Component instance with attrsSchema`, function() {
   });
 
   it(`updates attrs`, function() {
-    expect(el.attrs).to.deep.equal({
+    expect(JSON.stringify(el.attrs)).to.equal(JSON.stringify({
       'str-attr': `world`,
       'bool-attr': false,
       'number-attr': 0,
       'json-attr': null,
-    });
+    }));
   });
 
   it(`reacts to attr updates`, async function() {
@@ -227,12 +227,12 @@ describe(`Simple Component instance with attrsSchema`, function() {
     el.setAttribute(`number-attr`, `500843`);
     el.setAttribute(`json-attr`, `{"foo": "bae"}`);
 
-    expect(el.attrs).to.deep.equal({
+    expect(JSON.stringify(el.attrs)).to.equal(JSON.stringify({
       'str-attr': `💩🤒🤢☠️ -> 👻🎉💐🎊😱😍`,
       'bool-attr': false,
       'number-attr': 500843,
       'json-attr': {foo: `bae`},
-    });
+    }));
 
     await nextAnimationFrame();
 
@@ -266,12 +266,12 @@ describe(`Simple Component instance with attrsSchema`, function() {
 
   it(`has default attrs present after createElement`, function() {
     el = document.createElement(`attrs-reflection-app`);
-    expect(el.attrs).to.deep.equal({
+    expect(JSON.stringify(el.attrs)).to.equal(JSON.stringify({
       'str-attr': `hello`,
       'bool-attr': false,
       'number-attr': 0,
       'json-attr': null,
-    });
+    }));
     // _config is initialised in constructor. defaultState should be able to access el.attrs
     expect(el._config.defaultState.str).to.equal(`hello`);
   });

--- a/test/server/component.js
+++ b/test/server/component.js
@@ -131,12 +131,12 @@ describe(`Server-side component renderer`, function() {
     el.setAttribute(`number-attr`, `500843`);
     el.setAttribute(`json-attr`, `{"foo": "bae"}`);
 
-    expect(el.attrs).to.deep.equal({
+    expect(JSON.stringify(el.attrs)).to.equal(JSON.stringify({
       'str-attr': `world`,
       'bool-attr': false,
       'number-attr': 500843,
       'json-attr': {foo: `bae`},
-    });
+    }));
 
     await nextAnimationFrame();
 
@@ -158,12 +158,12 @@ describe(`Server-side component renderer`, function() {
     el.setAttribute(`json-attr`, `{"foo": not %%^ json`);
     el.connectedCallback();
 
-    expect(el.attrs).to.deep.equal({
+    expect(JSON.stringify(el.attrs)).to.equal(JSON.stringify({
       'str-attr': `💩🤒🤢☠️ -> 👻🎉💐🎊😱😍`,
       'bool-attr': true,
       'number-attr': null,
       'json-attr': null,
-    });
+    }));
 
     await nextAnimationFrame();
 
@@ -175,6 +175,15 @@ describe(`Server-side component renderer`, function() {
         <p>json-attr: null</p>
       </div>
     `));
+  });
+
+  it(`throws error for invalid attr access`, async function() {
+    const el = new AttrsReflectionApp();
+    el.connectedCallback();
+
+    expect(() => el.attrs[`bad-attr`]).to.throw(
+      `attr 'bad-attr' is not defined in attrSchema`
+    );
   });
 
   it(`throws error for invalid value in an enum attr`, function() {


### PR DESCRIPTION
This is alternate proposal to #62: It should preserve the existing public api as is. Thanks to Proxies we can validate array access.

This is really cool though. Already helped me catch two bugs in our component library. Exactly what I was expecting.

<img width="845" alt="image" src="https://user-images.githubusercontent.com/1018196/56506094-51375000-64d2-11e9-823f-1f492f5d2696.png">
