### PR TITLE
Make default state available at construction time and flush child state updates

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -271,13 +271,13 @@ class Component extends WebComponent {
       this.$panelParent.$panelChildren.add(this);
 
       // share either appState or all of state
-      Object.assign(this.$panelRoot.appState, this.appState); // flush any queued appState changes
-      this.appState = this.$panelRoot.appState;
-      this.isStateShared = this.$panelRoot.isStateShared;
+      // flush any queued appState changes
+      this.appState = Object.assign(this.$panelRoot.appState, this.appState);
 
       // if child element state is shared, point
       // state to parent's state object and flush any
       // queued state changes to the parent state
+      this.isStateShared = this.$panelRoot.isStateShared;
       if (this.isStateShared) {
         this.state = Object.assign(this.$panelRoot.state, this.state);
       }

--- a/lib/component.js
+++ b/lib/component.js
@@ -274,7 +274,13 @@ class Component extends WebComponent {
       Object.assign(this.$panelRoot.appState, this.appState); // flush any queued appState changes
       this.appState = this.$panelRoot.appState;
       this.isStateShared = this.$panelRoot.isStateShared;
-      this.state = this.isStateShared ? this.$panelRoot.state : {};
+
+      // if child element state is shared, point
+      // state to parent's state object and flush any
+      // queued state changes to the parent state
+      if (this.isStateShared) {
+        this.state = Object.assign(this.$panelRoot.state, this.state);
+      }
     } else {
       this.isPanelRoot = true;
       this.$panelRoot = this;

--- a/lib/component.js
+++ b/lib/component.js
@@ -217,7 +217,7 @@ class Component extends WebComponent {
     // initialize shared state store, either in `appState` or default to `state`
     // appState and isStateShared of child components will be overwritten by parent/root
     // when the component is connected to the hierarchy
-    this.state = {};
+    this.state = Object.assign({}, this.getConfig(`defaultState`));
     this.appState = this.getConfig(`appState`);
 
     if (!this.appState) {
@@ -275,7 +275,6 @@ class Component extends WebComponent {
       this.appState = this.$panelRoot.appState;
       this.isStateShared = this.$panelRoot.isStateShared;
       this.state = this.isStateShared ? this.$panelRoot.state : {};
-
     } else {
       this.isPanelRoot = true;
       this.$panelRoot = this;

--- a/lib/component.js
+++ b/lib/component.js
@@ -288,15 +288,10 @@ class Component extends WebComponent {
     }
     this.app = this.$panelRoot;
 
-    const newState = Object.assign(
-      {},
-      this.getConfig(`defaultState`),
-      this.state,
+    Object.assign(this.state,
       this.getJSONAttribute(`data-state`),
-      this._stateFromAttributes()
+      this._stateFromAttributes(),
     );
-
-    Object.assign(this.state, newState);
 
     if (Object.keys(this.getConfig(`routes`)).length) {
       this.router = new Router(this, {historyMethod: this.historyMethod});

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -307,7 +307,7 @@ describe(`Nested Component instance`, function() {
       expect(childEl.findPanelParentByTagName(`nested-app`)).to.equal(el);
     });
 
-    it(`flushes child state updates to parent`, async function() {
+    it(`flushes child state updates to parent`, function() {
       el.connectedCallback();
       expect(el.state).to.not.have.property(`childAnimal`);
       childEl = document.createElement(`nested-child`);
@@ -347,7 +347,7 @@ describe(`Nested Component instance`, function() {
       expect(childEl.textContent).to.include(`parent title: test`);
     });
 
-    it(`flushes child state to parent state`, async function() {
+    it(`flushes child state to parent state`, function() {
       expect(childEl.textContent).to.include(`child animal: fox`);
     });
 
@@ -423,7 +423,7 @@ describe(`Nested Component instance with partially shared state`, function() {
       expect(childEl.textContent).to.include(`child: parentOnlyState: undefined`);
     });
 
-    it(`flushes shared app state from child to parent`, async function() {
+    it(`flushes shared app state from child to parent`, function() {
       expect(childEl.textContent).to.include(`shared child animal: fox`);
     });
 

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -312,9 +312,23 @@ describe(`Nested Component instance`, function() {
       childEl = document.createElement(`nested-child`);
       childEl.$panelParentID = el.panelID;
       childEl.$panelParent = childEl.$panelRoot = el;
-      childEl.update({animal: `capybara`});
       childEl.connectedCallback();
+      childEl.update({animal: `capybara`});
       expect(el.state.animal).to.equal(`capybara`);
+    });
+
+    it.only(`flushes child state updates to parent`, async function() {
+      el.connectedCallback();
+      expect(el.state).to.not.have.all.keys(`animal`, `stateFromChild`);
+      childEl = document.createElement(`nested-child`);
+      childEl.$panelParentID = el.panelID;
+      childEl.$panelParent = childEl.$panelRoot = el;
+      // state updates happening in child menu should be flushed to parent when connected
+      expect(el.state).to.not.have.all.keys(`animal`, `stateFromChild`);
+      childEl.setAttribute(`animal`, `attribute-animal`);
+      childEl.connectedCallback();
+      expect(childEl.state).to.include({animal: `attribute-animal`, stateFromChild: `value`});
+      expect(el.state).to.include({animal: `attribute-animal`, stateFromChild: `value`});
     });
   });
 

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -317,7 +317,7 @@ describe(`Nested Component instance`, function() {
       expect(el.state.animal).to.equal(`capybara`);
     });
 
-    it.only(`flushes child state updates to parent`, async function() {
+    it(`flushes child state updates to parent`, async function() {
       el.connectedCallback();
       expect(el.state).to.not.have.all.keys(`animal`, `stateFromChild`);
       childEl = document.createElement(`nested-child`);

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -312,8 +312,8 @@ describe(`Nested Component instance`, function() {
       childEl = document.createElement(`nested-child`);
       childEl.$panelParentID = el.panelID;
       childEl.$panelParent = childEl.$panelRoot = el;
-      childEl.connectedCallback();
       childEl.update({animal: `capybara`});
+      childEl.connectedCallback();
       expect(el.state.animal).to.equal(`capybara`);
     });
   });

--- a/test/fixtures/nested-app.js
+++ b/test/fixtures/nested-app.js
@@ -14,13 +14,17 @@ export class NestedApp extends Component {
 
       template: state => h(`div`, {class: {'nested-foo': true}}, [
         h(`h1`, `Nested app: ${state.title}`),
-        this.child(`nested-child`, {attrs: {'state-animal': `llama`}}),
+        this.child(`nested-child`, {attrs: {'child-title': `test`, 'state-animal': `llama`}}),
       ]),
     };
   }
 }
 
 export class NestedChild extends Component {
+  static get attrsSchema() {
+    return {'animal': `string`};
+  }
+
   get config() {
     return {
       template: state => h(`div`, {class: {'nested-foo-child': true}}, [
@@ -28,5 +32,18 @@ export class NestedChild extends Component {
         h(`p`, `animal: ${state.animal}`),
       ]),
     };
+  }
+
+  attributeChangedCallback(attr, oldVal, newVal) {
+    super.attributeChangedCallback(attr, oldVal, newVal);
+
+    if (attr === `animal`) {
+      this.update({animal: newVal});
+    }
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.update({stateFromChild: `value`});
   }
 }

--- a/test/fixtures/nested-app.js
+++ b/test/fixtures/nested-app.js
@@ -14,7 +14,8 @@ export class NestedApp extends Component {
 
       template: state => h(`div`, {class: {'nested-foo': true}}, [
         h(`h1`, `Nested app: ${state.title}`),
-        this.child(`nested-child`, {attrs: {'child-title': `test`, 'state-animal': `llama`}}),
+        h(`h2`, `Nested child: ${state.childAnimal || `Not defined`}`),
+        this.child(`nested-child`, {attrs: {'child-animal': `fox`, 'state-animal': `llama`}}),
       ]),
     };
   }
@@ -22,7 +23,7 @@ export class NestedApp extends Component {
 
 export class NestedChild extends Component {
   static get attrsSchema() {
-    return {'animal': `string`};
+    return {'child-animal': `string`};
   }
 
   get config() {
@@ -30,6 +31,7 @@ export class NestedChild extends Component {
       template: state => h(`div`, {class: {'nested-foo-child': true}}, [
         h(`p`, `parent title: ${state.title}`),
         h(`p`, `animal: ${state.animal}`),
+        h(`p`, `child animal: ${state.childAnimal}`),
       ]),
     };
   }
@@ -37,13 +39,8 @@ export class NestedChild extends Component {
   attributeChangedCallback(attr, oldVal, newVal) {
     super.attributeChangedCallback(attr, oldVal, newVal);
 
-    if (attr === `animal`) {
-      this.update({animal: newVal});
+    if (attr === `child-animal`) {
+      this.update({childAnimal: newVal});
     }
-  }
-
-  connectedCallback() {
-    super.connectedCallback();
-    this.update({stateFromChild: `value`});
   }
 }

--- a/test/fixtures/nested-app.js
+++ b/test/fixtures/nested-app.js
@@ -14,7 +14,6 @@ export class NestedApp extends Component {
 
       template: state => h(`div`, {class: {'nested-foo': true}}, [
         h(`h1`, `Nested app: ${state.title}`),
-        h(`h2`, `Nested child: ${state.childAnimal || `Not defined`}`),
         this.child(`nested-child`, {attrs: {'child-animal': `fox`, 'state-animal': `llama`}}),
       ]),
     };

--- a/test/fixtures/nested-partial-state-app.js
+++ b/test/fixtures/nested-partial-state-app.js
@@ -18,13 +18,17 @@ export class NestedPartialStateParent extends Component {
         h(`p`, `parent: parentOnlyState: ${state.parentOnlyState}`),
         h(`p`, `parent: childOnlyState: ${state.childOnlyState}`),
         h(`p`, `parent: nonSharedStateExample: ${state.nonSharedStateExample}`),
-        this.child(`nested-partial-state-child`),
+        this.child(`nested-partial-state-child`, {attrs: {'child-animal': `fox`}}),
       ]),
     };
   }
 }
 
 export class NestedPartialStateChild extends Component {
+  static get attrsSchema() {
+    return {'child-animal': `string`};
+  }
+
   get config() {
     return {
       defaultState: {
@@ -35,11 +39,20 @@ export class NestedPartialStateChild extends Component {
 
       template: state => h(`div`, {class: {'nested-partial-child': true}}, [
         h(`p`, `shared title: ${state.$app.title}`),
+        h(`p`, `shared child animal: ${state.$app.childAnimal}`),
         h(`p`, `component-specific title: ${state.title}`),
         h(`p`, `childOnlyState: ${state.childOnlyState}`),
         h(`p`, `child: parentOnlyState: ${state.parentOnlyState}`),
         h(`p`, `child: nonSharedStateExample: ${state.nonSharedStateExample}`),
       ]),
     };
+  }
+
+  attributeChangedCallback(attr, oldVal, newVal) {
+    super.attributeChangedCallback(attr, oldVal, newVal);
+
+    if (attr === `child-animal`) {
+      this.updateApp({childAnimal: newVal});
+    }
   }
 }

--- a/test/server/component.js
+++ b/test/server/component.js
@@ -19,15 +19,11 @@ customElements.define(`attrs-reflection-app`, AttrsReflectionApp);
 describe(`Server-side component renderer`, function() {
   it(`can register and create components with document.createElement`, function() {
     const el = document.createElement(`simple-app`);
-    expect(el.state).to.eql({});
-    el.connectedCallback();
     expect(el.state).to.eql({foo: `bar`, baz: `qux`});
   });
 
   it(`supports class instantiation`, function() {
     const el = new SimpleApp();
-    expect(el.state).to.eql({});
-    el.connectedCallback();
     expect(el.state).to.eql({foo: `bar`, baz: `qux`});
   });
 

--- a/test/server/component.js
+++ b/test/server/component.js
@@ -69,7 +69,7 @@ describe(`Server-side component renderer`, function() {
     const nestedChild = el.childNodes[0].childNodes[1];
     expect(nestedChild.childNodes).to.have.lengthOf(1);
     expect(nestedChild.childNodes[0].className).to.equal(`nested-foo-child`);
-    expect(nestedChild.childNodes[0].childNodes).to.have.lengthOf(2);
+    expect(nestedChild.childNodes[0].childNodes).to.have.lengthOf(3);
 
     // check content/HTML output
     const html = el.innerHTML;
@@ -78,6 +78,7 @@ describe(`Server-side component renderer`, function() {
     expect(html.toLowerCase()).to.contain(`<div class="nested-foo-child">`);
     expect(html).to.contain(`parent title: test`);
     expect(html).to.contain(`animal: llama`);
+    expect(html).to.contain(`child animal: fox`);
   });
 
   it(`updates nested components`, async function() {


### PR DESCRIPTION
- Makes default `state` available at construction time so that it can be read on `attributeChangedCallback`.
- Similarly to how `appState` is flushed at `connectedCallback`, flush shared state updates from child component to the parent's state.