### PR TITLE
better disconnectedCallback to help with panel memory leak

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -328,8 +328,6 @@ class Component extends WebComponent {
 
     if (this.domPatcher) {
       this.el.removeChild(this.domPatcher.el);
-      this.domPatcher.vnode = null;
-      this.domPatcher.el = null;
       this.domPatcher = null;
       this._rendered = null;
     }

--- a/lib/component.js
+++ b/lib/component.js
@@ -328,13 +328,10 @@ class Component extends WebComponent {
 
     if (this.domPatcher) {
       this.el.removeChild(this.domPatcher.el);
+      this.domPatcher.vnode = null;
+      this.domPatcher.el = null;
       this.domPatcher = null;
       this._rendered = null;
-    }
-
-    if (this.getConfig(`useShadowDom`)) {
-      this.styleTag = null;
-      this.el = null;
     }
 
     this.initialized = false;

--- a/lib/component.js
+++ b/lib/component.js
@@ -332,6 +332,11 @@ class Component extends WebComponent {
       this._rendered = null;
     }
 
+    if (this.getConfig(`useShadowDom`)) {
+      this.styleTag = null;
+      this.el = null;
+    }
+
     this.initialized = false;
   }
 

--- a/lib/component.js
+++ b/lib/component.js
@@ -327,10 +327,7 @@ class Component extends WebComponent {
     }
 
     if (this.domPatcher) {
-      // ensure domPatcher does not lead to Detached HTMLElement references
       this.el.removeChild(this.domPatcher.el);
-      this.domPatcher.state = null;
-      this.domPatcher.renderFunc = null;
       this.domPatcher = null;
       this._rendered = null;
     }

--- a/lib/component.js
+++ b/lib/component.js
@@ -321,6 +321,7 @@ class Component extends WebComponent {
 
     if (this.domPatcher) {
       this.el.removeChild(this.domPatcher.el);
+      this.domPatcher.disconnect();
     }
 
     this.$panelRoot = null;

--- a/lib/component.js
+++ b/lib/component.js
@@ -314,13 +314,27 @@ class Component extends WebComponent {
     if (this.router) {
       this.router.unregisterListeners();
     }
+
     if (this.$panelParent) {
       this.$panelParent.$panelChildren.delete(this);
+      this.$panelParent = null;
     }
+
+    if (this.$panelRoot) {
+      this.$panelRoot = null;
+      this.appState = null;
+      this.app = null;
+    }
+
     if (this.domPatcher) {
+      // ensure domPatcher does not lead to Detached HTMLElement references
       this.el.removeChild(this.domPatcher.el);
+      this.domPatcher.state = null;
+      this.domPatcher.renderFunc = null;
+      this.domPatcher = null;
+      this._rendered = null;
     }
-    this.domPatcher = null;
+
     this.initialized = false;
   }
 

--- a/lib/component.js
+++ b/lib/component.js
@@ -317,21 +317,18 @@ class Component extends WebComponent {
 
     if (this.$panelParent) {
       this.$panelParent.$panelChildren.delete(this);
-      this.$panelParent = null;
-    }
-
-    if (this.$panelRoot) {
-      this.$panelRoot = null;
-      this.appState = null;
-      this.app = null;
     }
 
     if (this.domPatcher) {
       this.el.removeChild(this.domPatcher.el);
-      this.domPatcher = null;
-      this._rendered = null;
     }
 
+    this.$panelRoot = null;
+    this.$panelParent = null;
+    this.appState = null;
+    this.app = null;
+    this.domPatcher = null;
+    this._rendered = null;
     this.initialized = false;
   }
 

--- a/lib/dom-patcher.js
+++ b/lib/dom-patcher.js
@@ -69,6 +69,11 @@ export class DOMPatcher {
   }
 
   render() {
+    // if disconnected, don't render
+    if (!this.renderFunc) {
+      return;
+    }
+
     this.rendering = true;
     this.pending = false;
     this.state = this.pendingState;
@@ -77,5 +82,16 @@ export class DOMPatcher {
 
     patch(this.vnode, newVnode);
     this.vnode = newVnode;
+  }
+
+  disconnect() {
+    const vnode = this.vnode;
+    this.renderFunc = null;
+    this.state = null;
+    this.vnode = null;
+    this.el = null;
+    // patch with empty vnode to clear out listeners in tree
+    // this ensures we don't leave dangling DetachedHTMLElements blocking GC
+    patch(vnode, {sel: vnode.sel});
   }
 }

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -126,6 +126,25 @@ describe(`Simple Component instance`, function() {
     });
   });
 
+  context(`when detached from DOM`, function() {
+    beforeEach(async function() {
+      document.body.appendChild(el);
+      await nextAnimationFrame();
+      document.body.removeChild(el);
+      await nextAnimationFrame();
+    });
+
+    it(`disconnectedCallback deinitializes component`, function() {
+      expect(el.$panelRoot).to.equal(null);
+      expect(el.$panelParent).to.equal(null);
+      expect(el.appState).to.equal(null);
+      expect(el.app).to.equal(null);
+      expect(el.domPatcher).to.equal(null);
+      expect(el._rendered).to.equal(null);
+      expect(el.initialized).to.equal(false);
+    });
+  });
+
   context(`when using shadow DOM`, function() {
     beforeEach(async function() {
       el = document.createElement(`shadow-dom-app`);

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -127,14 +127,12 @@ describe(`Simple Component instance`, function() {
   });
 
   context(`when detached from DOM`, function() {
-    beforeEach(async function() {
+    it(`cleans up references to be GC friendly`, async function() {
       document.body.appendChild(el);
       await nextAnimationFrame();
       document.body.removeChild(el);
       await nextAnimationFrame();
-    });
 
-    it(`disconnectedCallback cleans up to be GC friendly`, function() {
       expect(el.$panelRoot).to.equal(null);
       expect(el.$panelParent).to.equal(null);
       expect(el.appState).to.equal(null);
@@ -142,6 +140,27 @@ describe(`Simple Component instance`, function() {
       expect(el.domPatcher).to.equal(null);
       expect(el._rendered).to.equal(null);
       expect(el.initialized).to.equal(false);
+    });
+  });
+
+  context(`when detached and re-attached to DOM multiple times`, function() {
+    it(`renders its template`, async function() {
+      document.body.appendChild(el);
+      await nextAnimationFrame();
+
+      for (let i = 0 ; i < 5; ++i) {
+        document.body.removeChild(el);
+        await nextAnimationFrame();
+        document.body.appendChild(el);
+        await nextAnimationFrame();
+      }
+
+      expect(document.querySelector(`simple-app`)).to.equal(el);
+      expect(el.textContent).to.equal([
+        `Value of foo: bar`,
+        `Value of baz: qux`,
+        `Foo capitalized: Bar`,
+      ].join(``));
     });
   });
 

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -134,7 +134,7 @@ describe(`Simple Component instance`, function() {
       await nextAnimationFrame();
     });
 
-    it(`disconnectedCallback deinitializes component`, function() {
+    it(`disconnectedCallback cleans up to be GC friendly`, function() {
       expect(el.$panelRoot).to.equal(null);
       expect(el.$panelParent).to.equal(null);
       expect(el.appState).to.equal(null);

--- a/test/server/dom-patcher.js
+++ b/test/server/dom-patcher.js
@@ -131,4 +131,16 @@ describe(`dom-patcher`, function() {
       expect(domPatcher.el.textContent).to.eql(`Value of foo: whew`);
     });
   });
+
+  context(`when disconnected`, function() {
+    it(`cleans up to be GC friendly`, function() {
+      const domPatcher = new DOMPatcher({foo: `bar`}, () => h(`div`));
+      domPatcher.disconnect();
+
+      expect(domPatcher.renderFunc).to.equal(null);
+      expect(domPatcher.state).to.equal(null);
+      expect(domPatcher.vnode).to.equal(null);
+      expect(domPatcher.el).to.equal(null);
+    });
+  });
 });

--- a/test/server/dom-patcher.js
+++ b/test/server/dom-patcher.js
@@ -133,7 +133,7 @@ describe(`dom-patcher`, function() {
   });
 
   context(`when disconnected`, function() {
-    it(`cleans up to be GC friendly`, function() {
+    it(`cleans up references to be GC friendly`, function() {
       const domPatcher = new DOMPatcher({foo: `bar`}, () => h(`div`));
       domPatcher.disconnect();
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1018196/61988681-6fcd4b80-afd9-11e9-8908-d7f7edb3dd2f.png)

I made a simple test to test that garbage collection is indeed happening.

```ts
import {h, Component, ConfigOptions} from 'panel';

interface AppState {
  showChild: boolean;
  count: number;
}

customElements.define(`mp-blah`, class Blah extends Component<{}, AppState> {
  get config(): ConfigOptions<{}, AppState> {
    return {
      template: ({$component, $app}) => (
        <div attrs={{}}>
          {$app.showChild && $component.child(`mp-blah-child`)}
        </div>
      ),
      defaultState: {
      },
      appState: {
        showChild: false,
        count: 0,
      },
    };
  }
});

customElements.define(`mp-blah-child`, class BlahChild extends Component<{}> {
  get config(): ConfigOptions<{}, AppState> {
    return {
      useShadowDom: true,
      template: ({$app}) => (
        <div attrs={{}}>
          {new Array(100).fill(0).map(() => (
            <div on={{click: this.helpers.handleClick}}>{`${$app && $app.count} `.repeat(30)}</div>
          ))}
        </div>
      ),
      helpers: {
        handleClick: ev => {
          console.log(`click`, this.el, ev);
        },
      },
    };
  }
});

window[`startProfile`] = function startProfile() {
  const intervalId = setInterval(() => {
    const blahEl: any = document.querySelector(`mp-blah`);
    const count = blahEl.appState.count;
    blahEl.updateApp({showChild: false});

    if (count > 100) {
      clearInterval(intervalId);
    } else {
      requestAnimationFrame(() => blahEl.updateApp({showChild: true, count: count + 1}));
    }

  }, 100);
};

document.querySelector(`.app`).innerHTML = `<mp-blah />`;

```


0 DetachedHTMLElements after. Memory stays the same and all the intermediate elements are garbage collected. It does indeed fix the leak 🎉 