### PR TITLE
Allow a function to be passed to `update`

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -174,12 +174,16 @@ class Component extends WebComponent {
    * Applies a state update, triggering a re-render check of the component as
    * well as any other components sharing the same state. This is the primary
    * means of updating the DOM in a Panel application.
-   * @param {object} [stateUpdate={}] - keys and values of entries to update in
+   * @param {object|function} [stateUpdate={}] - keys and values of entries to update in
    * the component's state object
    * @example
    * myWidget.update({name: 'Bob'});
    */
   update(stateUpdate={}) {
+    if (typeof stateUpdate === `function`) {
+      const stateUpdateResult = stateUpdate(this.state);
+      return this._updateStore(stateUpdateResult, {store: `state`, cascade: this.isStateShared});
+    }
     return this._updateStore(stateUpdate, {store: `state`, cascade: this.isStateShared});
   }
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -234,5 +234,5 @@ export class Component<State, AppState = {}, App = unknown, Attrs = AnyAttrs> ex
    * well as any other components sharing the same state. This is the primary
    * means of updating the DOM in a Panel application.
    */
-  update(stateUpdate?: Partial<State>): void;
+  update(stateUpdate?: Partial<State> | ((state: State) => Partial<State>)): void;
 }

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -100,6 +100,24 @@ describe(`Simple Component instance`, function() {
       expect(el.textContent).to.contain(`Foo capitalized: New value`);
     });
 
+    it(`re-renders when state is updated with update function`, async function() {
+      expect(el.textContent).to.contain(`Value of foo: bar`);
+      expect(el.textContent).to.contain(`Foo capitalized: Bar`);
+      el.update(() => ({foo: `new value`}));
+      await nextAnimationFrame();
+      expect(el.textContent).to.contain(`Value of foo: new value`);
+      expect(el.textContent).to.contain(`Foo capitalized: New value`);
+    });
+
+    it(`re-renders when state is updated with function accessing existing state`, async function() {
+      expect(el.textContent).to.contain(`Value of foo: bar`);
+      expect(el.textContent).to.contain(`Foo capitalized: Bar`);
+      el.update(state => ({foo: `new ${state.foo}`}));
+      await nextAnimationFrame();
+      expect(el.textContent).to.contain(`Value of foo: new bar`);
+      expect(el.textContent).to.contain(`Foo capitalized: New bar`);
+    });
+
     it(`does not re-render if shouldUpdate() returns false`, async function() {
       expect(el.textContent).to.contain(`Value of foo: bar`);
       el.update({foo: `meow`});


### PR DESCRIPTION
This allows a function to be passed to `update` instead of only a partial state object. The function passed is expected to return a partial state object and is given the current state as a parameter.

This behavior will allow for easier integration with libraries like `immer` for state updates, and can potentially allow for more reusable state update utilities because the update function is passed the current state and will not require access to `this`.

```js
this.update(state =>({foo: `updated value derived from ${state.bar}`}));
```