### PR TITLE
add attrs schema type to allow better return type on static attrsSchema

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -140,6 +140,10 @@ export interface AttrSchema {
   interface?: string;
 }
 
+export type AttrsSchema<T> = {
+  [attr in keyof T]: string | AttrSchema;
+};
+
 export interface AnyAttrs {
   [attr: string]: any;
 }


### PR DESCRIPTION
This change allows for better typing of `attrsSchema` return.

Example:
```ts
export interface MyCardAttrs {
  id: number;
  name: string;
}

export default class MyCard extends Component<MyCardState, {}, unknown, MyCardAttrs> {
  static get attrsSchema(): AttrsSchema<MyCardAttrs> {
    return {
      ...super.attrsSchema,
      id: `number`,
      name: `string`,
    };
  }
  // the rest of the component
}
```