### PR TITLE
fix logError usage

### DIFF
--- a/lib/component-utils/controlled-component.js
+++ b/lib/component-utils/controlled-component.js
@@ -58,7 +58,7 @@ export default class ControlledComponent extends Component {
           $attr: this.attr.bind(this),
         });
       } catch (e) {
-        this.logError(`Error while rendering ${this.toString()}`, this, e.stack);
+        this._logError(`Error while rendering ${this.toString()}`, this, e.stack);
       }
     }
     return this._rendered || EMPTY_DIV;


### PR DESCRIPTION
#68 renamed `logError` and missed this usage.