### PR TITLE
controller update

### DIFF
--- a/lib/component-utils/state-controller.js
+++ b/lib/component-utils/state-controller.js
@@ -23,8 +23,9 @@ class StateController {
   }
 
   // Discourage external users from using state directly
-  _update(props) {
-    this._store.update(props);
+  _update(stateUpdate) {
+    const stateUpdateResult = typeof stateUpdate === `function` ? stateUpdate(this.state) : stateUpdate;
+    this._store.update(stateUpdateResult);
   }
 
   subscribeUpdates(listener) {

--- a/test/browser/component-utils/controlled-app.js
+++ b/test/browser/component-utils/controlled-app.js
@@ -14,13 +14,25 @@ describe(`Controlled App`, function () {
     expect(() => el.update({foo: `not bar`})).to.throw(/update\(\) not allowed from component. Use controller/);
   });
 
-  it(`Behaves like normal component`, async function () {
+  it(`Behaves like normal component (partial update)`, async function () {
     let count = 0;
     expect(el.controller.state).to.be.eql({count});
     expect(el.textContent).to.contain(`Counter: ${count}`);
 
     el.querySelector(`button.incr`).click();
     count += 1;
+    expect(el.controller.state).to.be.eql({count});
+    await nextAnimationFrame();
+    expect(el.textContent).to.contain(`Counter: ${count}`);
+  });
+
+  it(`Behaves like normal component (function update)`, async function () {
+    let count = 0;
+    expect(el.controller.state).to.be.eql({count});
+    expect(el.textContent).to.contain(`Counter: ${count}`);
+
+    el.querySelector(`button.decr`).click();
+    count -= 1;
     expect(el.controller.state).to.be.eql({count});
     await nextAnimationFrame();
     expect(el.textContent).to.contain(`Counter: ${count}`);

--- a/test/fixtures/controlled-app.js
+++ b/test/fixtures/controlled-app.js
@@ -13,8 +13,7 @@ class CounterController extends StateController {
   }
 
   decrCounter() {
-    const count = this.state.count - 1;
-    this._update({count});
+    this._update((state) => ({count: state.count - 1}));
   }
 
   getCount() {


### PR DESCRIPTION
Our base component started supporting function updates with #76 but the same functionality was not given to controlled components.

This change enables controlled components to use `_update` in the same way that standard components can use `update`.