### PR TITLE
export jsx, similarly to h export

### DIFF
--- a/examples/jsx/README.md
+++ b/examples/jsx/README.md
@@ -1,7 +1,10 @@
 # Using JSX with Panel
 
 The example in this directory notates the basic 'counter app' from the [README](https://github.com/mixpanel/panel/blob/master/README.md) but using [JSX](https://facebook.github.io/jsx/) to inline the template:
+
 ```jsx
+import { Component, jsx } from 'panel';
+
 customElements.define('counter-app', class extends Component {
   get config() {
     return {
@@ -13,13 +16,13 @@ customElements.define('counter-app', class extends Component {
       },
 
       template: props =>
-        <div className="counter">
-          <div className="val">
+        <div sel=".counter">
+          <div sel=".val">
             Counter: {props.count}
           </div>
-          <div className="controls">
-            <button className="decr" on-click={props.$helpers.decr}>-</button>
-            <button className="incr" on-click={props.$helpers.incr}>+</button>
+          <div sel=".controls">
+            <button sel=".decr" on={{click: props.$helpers.decr}}>-</button>
+            <button sel=".incr" on={{click: props.$helpers.incr}}>+</button>
           </div>
         </div>
     };
@@ -35,6 +38,4 @@ To install and run the example from this directory: `npm install && npm start`. 
 
 ### Notes
 
-For transpiling JSX to JavaScript, this example uses the standard Babel plugin [transform-react-jsx](https://babeljs.io/docs/plugins/transform-react-jsx/). In order for the plugin's output to interface correctly with `snabbdom` instead of `React`, we use the [`snabbdom-jsx`](https://github.com/yelouafi/snabbdom-jsx) package and configure the Babel plugin to use the `html` Hyperscript function provided by `snabbdom-jsx`.
-
-Information on integrating Snabbdom-specific functionality (such as its dynamic class-toggling system) into JSX code can be found in [Mapping JSX attributes](https://github.com/yelouafi/snabbdom-jsx#mapping-jsx-attributes) from the `snabbdom-jsx` README.
+For transpiling JSX to JavaScript, this example uses the standard Babel plugin [transform-react-jsx](https://babeljs.io/docs/plugins/transform-react-jsx/). In order for the plugin's output to interface correctly with `snabbdom` instead of `React`, we use the [`snabbdom-jsx-lite`](https://github.com/nojvek/snabbdom-jsx-lite) package and configure the Babel plugin to use the `jsx` function re-exported by `panel`.

--- a/examples/jsx/index.jsx
+++ b/examples/jsx/index.jsx
@@ -1,7 +1,6 @@
 // import from the same repo. in a different repo you'd use:
 // import { Component } from 'panel';
-import { Component } from '../../lib';
-import { html } from 'snabbdom-jsx';
+import { Component, jsx } from '../../lib';
 
 customElements.define('counter-app', class extends Component {
   get config() {
@@ -14,13 +13,13 @@ customElements.define('counter-app', class extends Component {
       },
 
       template: props =>
-        <div className="counter">
-          <div className="val">
+        <div sel=".counter">
+          <div sel=".val">
             Counter: {props.count}
           </div>
-          <div className="controls">
-            <button className="decr" on-click={props.$helpers.decr}>-</button>
-            <button className="incr" on-click={props.$helpers.incr}>+</button>
+          <div sel=".controls">
+            <button sel=".decr" on={{click: props.$helpers.decr}}>-</button>
+            <button sel=".incr" on={{click: props.$helpers.incr}}>+</button>
           </div>
         </div>
     };

--- a/examples/jsx/package.json
+++ b/examples/jsx/package.json
@@ -10,7 +10,7 @@
   "author": "dev@mixpanel.com",
   "license": "MIT",
   "dependencies": {
-    "snabbdom-jsx": "0.3.1",
+    "snabbdom-jsx-lite": "1.0.10",
     "@webcomponents/custom-elements": "1.0.0-rc.3"
   },
   "devDependencies": {

--- a/examples/jsx/webpack.config.js
+++ b/examples/jsx/webpack.config.js
@@ -19,7 +19,7 @@ const webpackConfig = {
         exclude: /node_modules/,
         loader: `babel`,
         query: {
-          plugins: [[`transform-react-jsx`, {pragma: `html`}]],
+          plugins: [[`transform-react-jsx`, {pragma: `jsx`}]],
           presets: [`es2015`],
         },
       },

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -5,6 +5,7 @@ import {VNode} from 'snabbdom/vnode';
 import {WebComponent} from 'webcomponent';
 
 export {h} from 'snabbdom/h';
+export {jsx} from 'snabbdom-jsx-lite';
 
 export class StateStore<State> {
   constructor(options: {store?: StateStore<State>});

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@
 import Component from './component';
 import ComponentUtils from './component-utils';
 import {h} from './dom-patcher';
+import {jsx} from 'snabbdom-jsx-lite';
 
 const {ControlledComponent, ProxyComponent, StateController, StateStore} = ComponentUtils;
 
@@ -32,4 +33,9 @@ export {
    * exported here for user convenience
    */
   h,
+  /**
+   * `jsx` is similar to snabbdom's `h` function but supports jsx(tag, props, ...children) interface to create Hyperscript nodes.
+   * exported besides h for user convenience.
+   */
+  jsx,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11347,6 +11347,11 @@
       "resolved": "https://registry.npmjs.org/snabbdom-delayed-class/-/snabbdom-delayed-class-0.1.1.tgz",
       "integrity": "sha1-O73Iug7EiOqgtym/kwdowgfdJ30="
     },
+    "snabbdom-jsx-lite": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/snabbdom-jsx-lite/-/snabbdom-jsx-lite-1.0.9.tgz",
+      "integrity": "sha512-xy2xnUpambj5wp5H3bHMzygY320xvoDKYrf7/2yB0H41ubJhd8pzSNbU5zp7fVOxseOqk8zeQ7S654MSITezHQ=="
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11348,9 +11348,9 @@
       "integrity": "sha1-O73Iug7EiOqgtym/kwdowgfdJ30="
     },
     "snabbdom-jsx-lite": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/snabbdom-jsx-lite/-/snabbdom-jsx-lite-1.0.9.tgz",
-      "integrity": "sha512-xy2xnUpambj5wp5H3bHMzygY320xvoDKYrf7/2yB0H41ubJhd8pzSNbU5zp7fVOxseOqk8zeQ7S654MSITezHQ=="
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/snabbdom-jsx-lite/-/snabbdom-jsx-lite-1.0.10.tgz",
+      "integrity": "sha512-lUpUJVE+GGTCGpC/AJjBGQ9rL18SwJ7pr1LKjiCcMVIu3nKXDR0N9+c1MwQt4FIWRzRFEyWGK+2QTRqdENfvkg=="
     },
     "snapdragon": {
       "version": "0.8.2",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "schema-utils": "1.0.0",
     "snabbdom": "0.7.4",
     "snabbdom-delayed-class": "0.1.1",
+    "snabbdom-jsx-lite": "1.0.9",
     "webcomponent": "1.2.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "schema-utils": "1.0.0",
     "snabbdom": "0.7.4",
     "snabbdom-delayed-class": "0.1.1",
-    "snabbdom-jsx-lite": "1.0.9",
+    "snabbdom-jsx-lite": "1.0.10",
     "webcomponent": "1.2.1"
   },
   "devDependencies": {

--- a/test/fixtures/attrs-reflection-app.js
+++ b/test/fixtures/attrs-reflection-app.js
@@ -1,5 +1,5 @@
 // @ts-check
-import {Component, h} from '../../lib';
+import {Component, jsx} from '../../lib';
 
 const STR_ATTR = {
   HELLO: `hello`,
@@ -30,12 +30,12 @@ export class AttrsReflectionApp extends Component {
   get config() {
     return {
       template: (scope) =>
-        h(
+        jsx(
           `div`,
           {class: {'attrs-reflection-app': true}},
           Object.keys(scope.$component.attrs()).map(
             /** @param attr {keyof Attrs} */
-            (attr) => h(`p`, `${attr}: ${JSON.stringify(scope.$attr(attr))}`),
+            (attr) => jsx(`p`, null, `${attr}: ${JSON.stringify(scope.$attr(attr))}`),
           ),
         ),
       defaultState: {


### PR DESCRIPTION
snabbdom-jsx-lite uses snabbdom as a peer dependency. Since panel bundles snabbdom's h, it makes sense to export jsx helper too.