### PR TITLE
support external template functions with implicitly bound this and make template-hot-loader compatible with es6 modules

### DIFF
--- a/hot/template-loader.js
+++ b/hot/template-loader.js
@@ -14,13 +14,25 @@ module.exports.pitch = function (request) {
     return `module.exports = require(${moduleId});`;
   }
 
+  // hot reloading of templates works by exporting a wrapped closure function that references templateFn
+  // when we receive a new module update, we swap templateFn reference to new template function
+  // this means components that use the template don't need to change their function reference
+  // we just need to call their .update()
   return `
-    let template = require(${moduleId});
+    const getTemplateFn = (mod) => mod.__esModule ? mod.template : mod;
+    const templateModule = require(${moduleId});
+    let templateFn = getTemplateFn(templateModule);
+    const wrappedTemplateFn = function() {return templateFn.apply(this, arguments)};
     module.hot.accept(${moduleId}, () => {
-      template = require(${moduleId});
+      const templateModule = require(${moduleId});
+      templateFn = getTemplateFn(templateModule)
       const updatePanelElems = require('panel/hot/update-panel-elems');
       updatePanelElems('${elemName}', elem => true);
     });
-    module.exports = function() {return template.apply(this, arguments)};
+    if (templateModule.__esModule) {
+      module.exports = {...templateModule, __esModule: true, template: wrappedTemplateFn};
+    } else {
+      module.exports = wrappedTemplateFn;
+    }
   `;
 };

--- a/hot/template-loader.js
+++ b/hot/template-loader.js
@@ -20,15 +20,13 @@ module.exports.pitch = function (request) {
   // we just need to call their .update()
   return `
     const getTemplateFn = (mod) => mod.__esModule ? mod.template : mod;
-    const templateModule = require(${moduleId});
-    let templateFn = getTemplateFn(templateModule);
-    const wrappedTemplateFn = function() {return templateFn.apply(this, arguments)};
+    let templateFn = getTemplateFn(require(${moduleId}));
     module.hot.accept(${moduleId}, () => {
-      const templateModule = require(${moduleId});
-      templateFn = getTemplateFn(templateModule)
+      templateFn = getTemplateFn(require(${moduleId}))
       const updatePanelElems = require('panel/hot/update-panel-elems');
       updatePanelElems('${elemName}', elem => true);
     });
+    const wrappedTemplateFn = function() {return templateFn.apply(this, arguments)};
     if (templateModule.__esModule) {
       module.exports = {...templateModule, __esModule: true, template: wrappedTemplateFn};
     } else {

--- a/lib/component.js
+++ b/lib/component.js
@@ -414,7 +414,8 @@ class Component extends WebComponent {
   _render(state) {
     if (this.shouldUpdate(state)) {
       try {
-        this._rendered = this.getConfig(`template`)(
+        this._rendered = this.getConfig(`template`).call(
+          this,
           Object.assign({}, state, {
             $app: this.appState,
             $component: this,

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2,7 +2,7 @@
 // Project: panel
 // Definitions by: Mixpanel (https://mixpanel.com)
 import {VNode} from 'snabbdom/vnode';
-import {WebComponent} from 'webcomponent';
+import WebComponent from 'webcomponent';
 
 export {h} from 'snabbdom/h';
 export {jsx} from 'snabbdom-jsx-lite';

--- a/package-lock.json
+++ b/package-lock.json
@@ -13523,9 +13523,9 @@
       }
     },
     "webcomponent": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/webcomponent/-/webcomponent-1.2.1.tgz",
-      "integrity": "sha512-qoa/CDMxFK2h/4jNA4ow9OOUZnD2vw23+PDm18tmASaYiEn6k2bcFpDTKyus/JtUi0XF74pJa42PV5jrs4eZCA=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/webcomponent/-/webcomponent-1.2.2.tgz",
+      "integrity": "sha512-yy7ud9cWH8et+9dIHmwiPHmQlnm6JBt64Y7Nx4yg5QIQrx9TgD8KBxDrSxmYmPoaj/w2HjN7s1+7fuSFSSrCqg=="
     },
     "webidl-conversions": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "snabbdom": "0.7.4",
     "snabbdom-delayed-class": "0.1.1",
     "snabbdom-jsx-lite": "1.0.10",
-    "webcomponent": "1.2.1"
+    "webcomponent": "1.2.2"
   },
   "devDependencies": {
     "@webcomponents/custom-elements": "1.0.6",

--- a/test/fixtures/attrs-reflection-app.js
+++ b/test/fixtures/attrs-reflection-app.js
@@ -1,5 +1,6 @@
 // @ts-check
-import {Component, jsx} from '../../lib';
+import {Component} from '../../lib';
+import {template} from './attrs-reflection-template';
 
 const STR_ATTR = {
   HELLO: `hello`,
@@ -10,20 +11,6 @@ const STR_ATTR = {
 /** @typedef {{str: string}} State */
 /** @typedef {{'str-attr': string, 'bool-attr': boolean, 'number-attr': number, 'json-attr': any }} Attrs */
 /** @typedef {import('../../lib/index.d').ConfigOptions<State, {}, Attrs>} ConfigOptions*/
-
-/** @this {AttrsReflectionApp}
- * fixture example with `this` implicitly bound to the component instance
- */
-function template() {
-  return jsx(
-    `div`,
-    {class: {'attrs-reflection-app': true}},
-    Object.keys(this.attrs()).map(
-      /** @param attr {keyof Attrs} */
-      (attr) => jsx(`p`, null, `${attr}: ${JSON.stringify(this.attr(attr))}`),
-    ),
-  );
-}
 
 /** @extends {Component<State, unknown, unknown, Attrs>} */
 export class AttrsReflectionApp extends Component {

--- a/test/fixtures/attrs-reflection-app.js
+++ b/test/fixtures/attrs-reflection-app.js
@@ -11,6 +11,20 @@ const STR_ATTR = {
 /** @typedef {{'str-attr': string, 'bool-attr': boolean, 'number-attr': number, 'json-attr': any }} Attrs */
 /** @typedef {import('../../lib/index.d').ConfigOptions<State, {}, Attrs>} ConfigOptions*/
 
+/** @this {AttrsReflectionApp}
+ * fixture example with `this` implicitly bound to the component instance
+ */
+function template() {
+  return jsx(
+    `div`,
+    {class: {'attrs-reflection-app': true}},
+    Object.keys(this.attrs()).map(
+      /** @param attr {keyof Attrs} */
+      (attr) => jsx(`p`, null, `${attr}: ${JSON.stringify(this.attr(attr))}`),
+    ),
+  );
+}
+
 /** @extends {Component<State, unknown, unknown, Attrs>} */
 export class AttrsReflectionApp extends Component {
   static get attrsSchema() {
@@ -29,15 +43,7 @@ export class AttrsReflectionApp extends Component {
   /** @returns {ConfigOptions} */
   get config() {
     return {
-      template: (scope) =>
-        jsx(
-          `div`,
-          {class: {'attrs-reflection-app': true}},
-          Object.keys(scope.$component.attrs()).map(
-            /** @param attr {keyof Attrs} */
-            (attr) => jsx(`p`, null, `${attr}: ${JSON.stringify(scope.$attr(attr))}`),
-          ),
-        ),
+      template,
       defaultState: {
         // Typescript will infer attr(`str-attr`) returns a string.
         // Changing to 'bad-attr' will fail npm run type-check

--- a/test/fixtures/attrs-reflection-template.js
+++ b/test/fixtures/attrs-reflection-template.js
@@ -1,0 +1,19 @@
+// @ts-check
+import {jsx} from '../../lib';
+
+/** @typedef {import('./attrs-reflection-app').AttrsReflectionApp} AttrsReflectionApp*/
+/** @typedef {import('./attrs-reflection-app').Attrs} Attrs*/
+
+/** @this {AttrsReflectionApp}
+ * fixture example of external template with `this` implicitly bound
+ */
+export function template() {
+  return jsx(
+    `div`,
+    {class: {'attrs-reflection-app': true}},
+    Object.keys(this.attrs()).map(
+      /** @param attr {keyof Attrs} */
+      (attr) => jsx(`p`, null, `${attr}: ${JSON.stringify(this.attr(attr))}`),
+    ),
+  );
+}


### PR DESCRIPTION
support templates as external functions with this implicitly bound. Improved test fixture.

Webcomponent upgrade contains proper type fix for WebComponent.

Make hot loader work with templates as external modules.
