### PR TITLE
Panel Contexts for propagating objects to DOM-descendant components

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -768,7 +768,7 @@ class Component extends WebComponent {
     }
   }
 
-  _findNearestContextParent() {
+  _findNearestContextAncestor() {
     if (!this.isConnected) {
       throw new Error(`Cannot determine context before component is connected to the DOM`);
     }
@@ -788,23 +788,23 @@ class Component extends WebComponent {
     return null;
   }
 
-  _findAndMergeActiveContexts() {
-    const contextParent = this._findNearestContextParent();
+  _findAndMergeContextsFromAncestors() {
+    const contextAncestor = this._findNearestContextAncestor();
     const defaultContexts = Object.assign({}, this.getConfig(`defaultContexts`));
 
-    if (contextParent) {
-      // parent contexts must override locally defined defaults
-      return Object.assign(defaultContexts, contextParent._getAvailableContexts());
+    if (contextAncestor) {
+      // ancestor contexts must override locally defined defaults
+      return Object.assign(defaultContexts, contextAncestor._getAvailableContexts());
     }
 
     return defaultContexts;
   }
 
   _getAvailableContexts() {
-    if (!this._cachedActiveContexts) {
-      this._cachedActiveContexts = this._findAndMergeActiveContexts();
+    if (!this._cachedContexts) {
+      this._cachedContexts = this._findAndMergeContextsFromAncestors();
     }
-    return this._cachedActiveContexts;
+    return this._cachedContexts;
   }
 
   getContext(contextName) {

--- a/lib/component.js
+++ b/lib/component.js
@@ -387,7 +387,7 @@ class Component extends WebComponent {
 
     for (const contextName of this.getConfig(`contexts`)) {
       const context = this.getContext(contextName);
-      // Context classes can implement an optional `bindToComponent`` callback that executes each time the component is connected to the DOM
+      // Context classes can implement an optional `bindToComponent` callback that executes each time the component is connected to the DOM
       if (context.bindToComponent) {
         context.bindToComponent(this);
       }

--- a/lib/component.js
+++ b/lib/component.js
@@ -279,6 +279,7 @@ class Component extends WebComponent {
       {},
       {
         css: ``,
+        defaultContexts: new Map(),
         helpers: {},
         routes: {},
         template: () => {
@@ -312,6 +313,25 @@ class Component extends WebComponent {
       throw Error(`"useShadowDom" config option must be set in order to use "css" config.`);
     } else {
       this.el = this;
+    }
+
+    const defaultContexts = this.getConfig(`defaultContexts`);
+    if (!(defaultContexts instanceof Map)) {
+      throw new Error(`"defaultContexts" config option must be a Map`);
+    }
+    for (const [baseContextClass, defaultContext] of defaultContexts.entries()) {
+      if (!baseContextClass || !baseContextClass.constructor) {
+        throw new Error(`"defaultContexts" config option Map must contain class definitions as keys`);
+      }
+      if (!defaultContext || !baseContextClass.constructor) {
+        throw new Error(`"defaultContexts" config option Map must contain class instances as values`);
+      }
+      if (defaultContext.constructor.name === baseContextClass.constructor.name) {
+        throw new Error(`"defaultContexts" config option Map key must be a different class from the class of its value. Please define an abstract base class that declares the context's capabilities and use it as the key.`);
+      }
+      if (!(defaultContext instanceof baseContextClass)) {
+        throw new Error(`"defaultContexts" config option Map value must inherit from the class definition used as the key. Please define a class that implements the capabilities declared by the key class.`)
+      }
     }
   }
 
@@ -512,6 +532,7 @@ class Component extends WebComponent {
             $hooks: hookHelpers,
           }),
         );
+        // this._rendered.data.panelContext = this._getActiveContexts();
       } catch (error) {
         this._logError(`Error while rendering`, this, `\n`, error);
         this.dispatchEvent(
@@ -748,6 +769,41 @@ class Component extends WebComponent {
         }
       }
     }
+  }
+
+  /**
+   * @param {Map<{ new(): any}, any>} contexts - contexts provided by parent panel component
+   */
+  _receiveContexts(contexts) {
+    this._parentContexts = contexts;
+  }
+
+  _getActiveContexts() {
+    const parentContexts = this._parentContexts || new Map();
+    const activeContexts = new Map(parentContexts.entries());
+
+    const defaultContexts = this.getConfig(`defaultContexts`);
+    for (const [baseContextClass, defaultContext] of defaultContexts.entries()) {
+      if (!activeContexts.has(baseContextClass)) {
+        activeContexts.set(baseContextClass, defaultContext);
+      }
+    }
+    return activeContexts;
+  }
+
+  getContext(contextBaseClass) {
+    if (!contextBaseClass) {
+      throw new Error(`@contextBaseClass is null or undefined`);
+    }
+    const defaultContexts = this.getConfig(`defaultContexts`);
+    const defaultContext = defaultContexts.get(contextBaseClass);
+    if (!defaultContext) {
+      throw new Error(`A default context must be declared in config.defaultContexts before this context can be used.`);
+    }
+    if (this._parentContexts && this._parentContexts.has(contextBaseClass)) {
+      return this._parentContexts.get(contextBaseClass);
+    }
+    return defaultContext;
   }
 }
 

--- a/lib/component.js
+++ b/lib/component.js
@@ -811,7 +811,9 @@ class Component extends WebComponent {
     }
 
     if (!(contextName in this._getAvailableContexts())) {
-      throw new Error(`A "${contextName}" context is not available. Check that this component or a DOM ancestor has provided a context in its "defaultContexts" Panel config.`);
+      throw new Error(
+        `A "${contextName}" context is not available. Check that this component or a DOM ancestor has provided a context in its "defaultContexts" Panel config.`,
+      );
     }
 
     return this._getAvailableContexts()[contextName];

--- a/lib/component.js
+++ b/lib/component.js
@@ -280,7 +280,7 @@ class Component extends WebComponent {
       {
         css: ``,
         defaultContexts: {},
-        attachedContexts: [],
+        contexts: [],
         helpers: {},
         routes: {},
         template: () => {
@@ -292,7 +292,7 @@ class Component extends WebComponent {
       this.config,
     );
 
-    this._attachedContexts = new Set(this.getConfig(`attachedContexts`));
+    this._contexts = new Set(this.getConfig(`contexts`));
 
     // initialize shared state store, either in `appState` or default to `state`
     // appState and isStateShared of child components will be overwritten by parent/root
@@ -385,10 +385,10 @@ class Component extends WebComponent {
       this.navigate(window.location.hash);
     }
 
-    for (const contextName of this.getConfig(`attachedContexts`)) {
+    for (const contextName of this.getConfig(`contexts`)) {
       const context = this.getContext(contextName);
-      if (context.attachedCallback) {
-        context.attachedCallback(this);
+      if (context.bindToComponent) {
+        context.bindToComponent(this);
       }
     }
 
@@ -426,10 +426,10 @@ class Component extends WebComponent {
 
     this._disconnectedQueue = this._disconnectedQueue.filter((fn) => !fn.removeAfterExec);
 
-    for (const contextName of this.getConfig(`attachedContexts`)) {
+    for (const contextName of this.getConfig(`contexts`)) {
       const context = this.getContext(contextName);
-      if (context.unattachedCallback) {
-        context.unattachedCallback(this);
+      if (context.unbindFromComponent) {
+        context.unbindFromComponent(this);
       }
     }
 
@@ -812,8 +812,8 @@ class Component extends WebComponent {
       throw new Error(`@contextName is null or empty`);
     }
 
-    if (!this._attachedContexts.has(contextName)) {
-      throw new Error(`@contextName must be declared in the "attachedContexts" config array`);
+    if (!this._contexts.has(contextName)) {
+      throw new Error(`@contextName must be declared in the "contexts" config array`);
     }
 
     if (!(contextName in this._getAvailableContexts())) {

--- a/lib/component.js
+++ b/lib/component.js
@@ -327,10 +327,14 @@ class Component extends WebComponent {
         throw new Error(`"defaultContexts" config option Map must contain class instances as values`);
       }
       if (defaultContext.constructor.name === baseContextClass.constructor.name) {
-        throw new Error(`"defaultContexts" config option Map key must be a different class from the class of its value. Please define an abstract base class that declares the context's capabilities and use it as the key.`);
+        throw new Error(
+          `"defaultContexts" config option Map key must be a different class from the class of its value. Please define an abstract base class that declares the context's capabilities and use it as the key.`,
+        );
       }
       if (!(defaultContext instanceof baseContextClass)) {
-        throw new Error(`"defaultContexts" config option Map value must inherit from the class definition used as the key. Please define a class that implements the capabilities declared by the key class.`);
+        throw new Error(
+          `"defaultContexts" config option Map value must inherit from the class definition used as the key. Please define a class that implements the capabilities declared by the key class.`,
+        );
       }
     }
   }

--- a/lib/component.js
+++ b/lib/component.js
@@ -330,7 +330,7 @@ class Component extends WebComponent {
         throw new Error(`"defaultContexts" config option Map key must be a different class from the class of its value. Please define an abstract base class that declares the context's capabilities and use it as the key.`);
       }
       if (!(defaultContext instanceof baseContextClass)) {
-        throw new Error(`"defaultContexts" config option Map value must inherit from the class definition used as the key. Please define a class that implements the capabilities declared by the key class.`)
+        throw new Error(`"defaultContexts" config option Map value must inherit from the class definition used as the key. Please define a class that implements the capabilities declared by the key class.`);
       }
     }
   }

--- a/lib/component.js
+++ b/lib/component.js
@@ -279,7 +279,8 @@ class Component extends WebComponent {
       {},
       {
         css: ``,
-        defaultContexts: new Map(),
+        defaultContexts: {},
+        attachedContexts: [],
         helpers: {},
         routes: {},
         template: () => {
@@ -313,29 +314,6 @@ class Component extends WebComponent {
       throw Error(`"useShadowDom" config option must be set in order to use "css" config.`);
     } else {
       this.el = this;
-    }
-
-    const defaultContexts = this.getConfig(`defaultContexts`);
-    if (!(defaultContexts instanceof Map)) {
-      throw new Error(`"defaultContexts" config option must be a Map`);
-    }
-    for (const [baseContextClass, defaultContext] of defaultContexts.entries()) {
-      if (!baseContextClass || !baseContextClass.constructor) {
-        throw new Error(`"defaultContexts" config option Map must contain class definitions as keys`);
-      }
-      if (!defaultContext || !baseContextClass.constructor) {
-        throw new Error(`"defaultContexts" config option Map must contain class instances as values`);
-      }
-      if (defaultContext.constructor.name === baseContextClass.constructor.name) {
-        throw new Error(
-          `"defaultContexts" config option Map key must be a different class from the class of its value. Please define an abstract base class that declares the context's capabilities and use it as the key.`,
-        );
-      }
-      if (!(defaultContext instanceof baseContextClass)) {
-        throw new Error(
-          `"defaultContexts" config option Map value must inherit from the class definition used as the key. Please define a class that implements the capabilities declared by the key class.`,
-        );
-      }
     }
   }
 
@@ -405,6 +383,13 @@ class Component extends WebComponent {
       this.navigate(window.location.hash);
     }
 
+    for (const contextName of this.getConfig(`attachedContexts`)) {
+      const context = this.getContext(contextName);
+      if (context.attachedCallback) {
+        context.attachedCallback(this);
+      }
+    }
+
     this.domPatcher = new DOMPatcher(this.state, this._render.bind(this), {
       updateMode: this.getConfig(`updateSync`) ? `sync` : `async`,
     });
@@ -438,6 +423,13 @@ class Component extends WebComponent {
     }
 
     this._disconnectedQueue = this._disconnectedQueue.filter((fn) => !fn.removeAfterExec);
+
+    for (const contextName of this.getConfig(`attachedContexts`)) {
+      const context = this.getContext(contextName);
+      if (context.unattachedCallback) {
+        context.unattachedCallback(this);
+      }
+    }
 
     if (this.router) {
       this.router.unregisterListeners();
@@ -774,17 +766,18 @@ class Component extends WebComponent {
     }
   }
 
-  _findNearestPanelAncestor() {
+  _findNearestContextParent() {
     if (!this.isConnected) {
       throw new Error(`Cannot determine context before component is connected to the DOM`);
     }
 
     let node = this.parentNode;
     while (node) {
-      if (node._getActiveContexts) {
+      if (node._getAvailableContexts) {
         return node;
       }
-      if (node.constructor.name === `ShadowRoot`) {
+      if (node.nodeType === DOCUMENT_FRAGMENT_NODE) {
+        // handle shadow-root
         node = node.host;
       } else {
         node = node.parentNode;
@@ -794,46 +787,34 @@ class Component extends WebComponent {
   }
 
   _findAndMergeActiveContexts() {
-    const contextParent = this._findNearestPanelAncestor();
-    const defaultContexts = this.getConfig(`defaultContexts`);
+    const contextParent = this._findNearestContextParent();
+    const defaultContexts = Object.assign({}, this.getConfig(`defaultContexts`));
 
     if (contextParent) {
-      const parentContexts = contextParent._getActiveContexts();
-
-      if (parentContexts.size > 0) {
-        // merge context maps
-        const combinedContexts = new Map(parentContexts.entries());
-        for (const [baseContextClass, defaultContext] of defaultContexts.entries()) {
-          if (!combinedContexts.has(baseContextClass)) {
-            combinedContexts.set(baseContextClass, defaultContext);
-          }
-        }
-
-        return combinedContexts;
-      }
+      // parent contexts must override locally defined defaults
+      return Object.assign(defaultContexts, contextParent._getAvailableContexts());
     }
 
     return defaultContexts;
   }
 
-  _getActiveContexts() {
+  _getAvailableContexts() {
     if (!this._cachedActiveContexts) {
       this._cachedActiveContexts = this._findAndMergeActiveContexts();
     }
     return this._cachedActiveContexts;
   }
 
-  getContext(contextBaseClass) {
-    if (!contextBaseClass) {
-      throw new Error(`@contextBaseClass is null or undefined`);
-    }
-    const defaultContexts = this.getConfig(`defaultContexts`);
-    const defaultContext = defaultContexts.get(contextBaseClass);
-    if (!defaultContext) {
-      throw new Error(`A default context must be declared in config.defaultContexts before this context can be used.`);
+  getContext(contextName) {
+    if (!contextName) {
+      throw new Error(`@contextName is null or empty`);
     }
 
-    return this._getActiveContexts().get(contextBaseClass);
+    if (!(contextName in this._getAvailableContexts())) {
+      throw new Error(`A "${contextName}" context is not available. Check that this component or a DOM ancestor has provided a context in its "defaultContexts" Panel config.`);
+    }
+
+    return this._getAvailableContexts()[contextName];
   }
 }
 

--- a/lib/component.js
+++ b/lib/component.js
@@ -532,7 +532,6 @@ class Component extends WebComponent {
             $hooks: hookHelpers,
           }),
         );
-        // this._rendered.data.panelContext = this._getActiveContexts();
       } catch (error) {
         this._logError(`Error while rendering`, this, `\n`, error);
         this.dispatchEvent(
@@ -771,24 +770,53 @@ class Component extends WebComponent {
     }
   }
 
-  /**
-   * @param {Map<{ new(): any}, any>} contexts - contexts provided by parent panel component
-   */
-  _receiveContexts(contexts) {
-    this._parentContexts = contexts;
+  _findNearestPanelAncestor() {
+    if (!this.isConnected) {
+      throw new Error(`Cannot determine context before component is connected to the DOM`);
+    }
+
+    let node = this.parentNode;
+    while (node) {
+      if (node._getActiveContexts) {
+        return node;
+      }
+      if (node.constructor.name === `ShadowRoot`) {
+        node = node.host;
+      } else {
+        node = node.parentNode;
+      }
+    }
+    return null;
+  }
+
+  _findAndMergeActiveContexts() {
+    const contextParent = this._findNearestPanelAncestor();
+    const defaultContexts = this.getConfig(`defaultContexts`);
+
+    if (contextParent) {
+      const parentContexts = contextParent._getActiveContexts();
+
+      if (parentContexts.size > 0) {
+        // merge context maps
+        const combinedContexts = new Map(parentContexts.entries());
+        for (const [baseContextClass, defaultContext] of defaultContexts.entries()) {
+          if (!combinedContexts.has(baseContextClass)) {
+            combinedContexts.set(baseContextClass, defaultContext);
+          }
+        }
+
+        return combinedContexts;
+      }
+    }
+
+    return defaultContexts;
   }
 
   _getActiveContexts() {
-    const parentContexts = this._parentContexts || new Map();
-    const activeContexts = new Map(parentContexts.entries());
-
-    const defaultContexts = this.getConfig(`defaultContexts`);
-    for (const [baseContextClass, defaultContext] of defaultContexts.entries()) {
-      if (!activeContexts.has(baseContextClass)) {
-        activeContexts.set(baseContextClass, defaultContext);
-      }
+    if (!this._cachedActiveContexts) {
+      this._cachedActiveContexts = this._findAndMergeActiveContexts();
     }
-    return activeContexts;
+    return this._cachedActiveContexts;
   }
 
   getContext(contextBaseClass) {
@@ -800,10 +828,8 @@ class Component extends WebComponent {
     if (!defaultContext) {
       throw new Error(`A default context must be declared in config.defaultContexts before this context can be used.`);
     }
-    if (this._parentContexts && this._parentContexts.has(contextBaseClass)) {
-      return this._parentContexts.get(contextBaseClass);
-    }
-    return defaultContext;
+
+    return this._getActiveContexts().get(contextBaseClass);
   }
 }
 

--- a/lib/component.js
+++ b/lib/component.js
@@ -826,13 +826,14 @@ class Component extends WebComponent {
       throw new Error(`@contextName must be declared in the "contexts" config array`);
     }
 
-    if (!(contextName in this._getAvailableContexts())) {
+    const availableContexts = this._getAvailableContexts();
+    if (!(contextName in availableContexts)) {
       throw new Error(
         `A "${contextName}" context is not available. Check that this component or a DOM ancestor has provided this context in its "defaultContexts" Panel config.`,
       );
     }
 
-    return this._getAvailableContexts()[contextName];
+    return availableContexts[contextName];
   }
 }
 

--- a/lib/component.js
+++ b/lib/component.js
@@ -387,6 +387,7 @@ class Component extends WebComponent {
 
     for (const contextName of this.getConfig(`contexts`)) {
       const context = this.getContext(contextName);
+      // Context classes can implement an optional `bindToComponent`` callback that executes each time the component is connected to the DOM
       if (context.bindToComponent) {
         context.bindToComponent(this);
       }
@@ -428,6 +429,7 @@ class Component extends WebComponent {
 
     for (const contextName of this.getConfig(`contexts`)) {
       const context = this.getContext(contextName);
+      // Context classes can implement an optional `unbindFromComponent`` callback that executes each time the component is disconnected from the DOM
       if (context.unbindFromComponent) {
         context.unbindFromComponent(this);
       }
@@ -809,8 +811,8 @@ class Component extends WebComponent {
 
   /**
    * Returns the default context of the highest (ie. closest to the document root) ancestor component
-   * that has configured a default context for the context name,
-   * or it will return the component's own default context if no ancestor context was found.
+   * that has configured a default context for the context name. If no ancestor context is found, it will
+   * return the component's own default context.
    *
    * @param {string} contextName - name of context
    * @returns {object} context object

--- a/lib/component.js
+++ b/lib/component.js
@@ -429,7 +429,7 @@ class Component extends WebComponent {
 
     for (const contextName of this.getConfig(`contexts`)) {
       const context = this.getContext(contextName);
-      // Context classes can implement an optional `unbindFromComponent`` callback that executes each time the component is disconnected from the DOM
+      // Context classes can implement an optional `unbindFromComponent` callback that executes each time the component is disconnected from the DOM
       if (context.unbindFromComponent) {
         context.unbindFromComponent(this);
       }

--- a/lib/component.js
+++ b/lib/component.js
@@ -807,6 +807,13 @@ class Component extends WebComponent {
     return this._cachedContexts;
   }
 
+  /**
+   * Returns the default context of the highest (ie. closest to the document root) ancestor component that has configured a default context for the context name,
+   * or it will return the component's own default context if no ancestor context was found.
+   *
+   * @param {string} contextName - name of context
+   * @returns {object} context object
+   */
   getContext(contextName) {
     if (!contextName) {
       throw new Error(`@contextName is null or empty`);

--- a/lib/component.js
+++ b/lib/component.js
@@ -808,7 +808,8 @@ class Component extends WebComponent {
   }
 
   /**
-   * Returns the default context of the highest (ie. closest to the document root) ancestor component that has configured a default context for the context name,
+   * Returns the default context of the highest (ie. closest to the document root) ancestor component
+   * that has configured a default context for the context name,
    * or it will return the component's own default context if no ancestor context was found.
    *
    * @param {string} contextName - name of context

--- a/lib/component.js
+++ b/lib/component.js
@@ -292,6 +292,8 @@ class Component extends WebComponent {
       this.config,
     );
 
+    this._attachedContexts = new Set(this.getConfig(`attachedContexts`));
+
     // initialize shared state store, either in `appState` or default to `state`
     // appState and isStateShared of child components will be overwritten by parent/root
     // when the component is connected to the hierarchy
@@ -810,9 +812,13 @@ class Component extends WebComponent {
       throw new Error(`@contextName is null or empty`);
     }
 
+    if (!this._attachedContexts.has(contextName)) {
+      throw new Error(`@contextName must be declared in the "attachedContexts" config array`);
+    }
+
     if (!(contextName in this._getAvailableContexts())) {
       throw new Error(
-        `A "${contextName}" context is not available. Check that this component or a DOM ancestor has provided a context in its "defaultContexts" Panel config.`,
+        `A "${contextName}" context is not available. Check that this component or a DOM ancestor has provided this context in its "defaultContexts" Panel config.`,
       );
     }
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -73,6 +73,9 @@ export interface ConfigOptions<StateT, AppStateT = unknown> {
   /** An initial default value for the component's state property */
   defaultState?: StateT;
 
+  /** Expected contexts and their default values to share with descendant panel components */
+  defaultContexts?: Map<{ new(): any }, any>;
+
   /**
    * A state object to share with nested descendant components. If not set, root component
    * shares entire state object with all descendants. Only applicable to app root components.
@@ -243,4 +246,6 @@ export class Component<StateT, AttrsT = AnyAttrs, AppStateT = unknown, AppT = un
    * removed from the DOM. This occurs during the disconnectedCallback lifecycle.
    */
   onDisconnected(callback: () => void): void;
+
+  getContext<BaseContext>(contextBaseClass: { new(): BaseContext }): BaseContext;
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -65,8 +65,8 @@ export interface PanelHooks<State> {
 
 // this type is not checked in the Component ContextRegistry, the Component JS manually checks for these properties instead
 export interface PanelLifecycleContext {
-  attachedCallback?(component: Component<any>): void;
-  unattachedCallback?(component: Component<any>): void;
+  bindToComponent?(component: Component<any>): void;
+  unbindFromComponent?(component: Component<any>): void;
 }
 
 export interface ConfigOptions<StateT, AppStateT = unknown, ContextRegistry = unknown> {
@@ -83,7 +83,7 @@ export interface ConfigOptions<StateT, AppStateT = unknown, ContextRegistry = un
   defaultContexts?: Partial<ContextRegistry>;
 
   /** Names of contexts for the component to attach and depend upon */
-  attachedContexts?: Array<keyof ContextRegistry>;
+  contexts?: Array<keyof ContextRegistry>;
 
   /**
    * A state object to share with nested descendant components. If not set, root component

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -74,7 +74,7 @@ export interface ConfigOptions<StateT, AppStateT = unknown> {
   defaultState?: StateT;
 
   /** Expected contexts and their default values to share with descendant panel components */
-  defaultContexts?: Map<{ new(): any }, any>;
+  defaultContexts?: Map<{new (): any}, any>;
 
   /**
    * A state object to share with nested descendant components. If not set, root component
@@ -247,5 +247,5 @@ export class Component<StateT, AttrsT = AnyAttrs, AppStateT = unknown, AppT = un
    */
   onDisconnected(callback: () => void): void;
 
-  getContext<BaseContext>(contextBaseClass: { new(): BaseContext }): BaseContext;
+  getContext<BaseContext>(contextBaseClass: {new (): BaseContext}): BaseContext;
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -265,5 +265,9 @@ export class Component<
    */
   onDisconnected(callback: () => void): void;
 
+  /**
+   * Returns the default context of the highest (ie. closest to the document root) ancestor component that has configured a default context for the context name,
+   * or it will return the component's own default context if no ancestor context was found.
+   */
   getContext<ContextKey extends keyof ContextRegistryT>(contextName: ContextKey): ContextRegistryT[ContextKey];
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -74,7 +74,7 @@ export interface ConfigOptions<StateT, AppStateT = unknown> {
   defaultState?: StateT;
 
   /** Expected contexts and their default values to share with descendant panel components */
-  defaultContexts?: Map<{new (): any}, any>;
+  defaultContexts?: Map<new () => any, any>;
 
   /**
    * A state object to share with nested descendant components. If not set, root component
@@ -247,5 +247,5 @@ export class Component<StateT, AttrsT = AnyAttrs, AppStateT = unknown, AppT = un
    */
   onDisconnected(callback: () => void): void;
 
-  getContext<BaseContext>(contextBaseClass: {new (): BaseContext}): BaseContext;
+  getContext<BaseContext>(contextBaseClass: new () => BaseContext): BaseContext;
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -143,7 +143,13 @@ export interface AnyAttrs {
   [attr: string]: any;
 }
 
-export class Component<StateT, AttrsT = AnyAttrs, AppStateT = unknown, AppT = unknown, ContextRegistry = unknown> extends WebComponent {
+export class Component<
+  StateT,
+  AttrsT = AnyAttrs,
+  AppStateT = unknown,
+  AppT = unknown,
+  ContextRegistry = unknown
+> extends WebComponent {
   /** The first Panel Component ancestor in the DOM tree; null if this component is the root */
   $panelParent: Component<unknown>;
 
@@ -202,7 +208,10 @@ export class Component<StateT, AttrsT = AnyAttrs, AppStateT = unknown, AppT = un
   getConfig<K extends keyof ConfigOptions<StateT, AppStateT, ContextRegistry>>(key: K): this['config'][K];
 
   /** Sets a value in the component's configuration map after element initialization */
-  setConfig<K extends keyof ConfigOptions<StateT, AppStateT, ContextRegistry>>(key: K, val: ConfigOptions<StateT, AppStateT, ContextRegistry>[K]): void;
+  setConfig<K extends keyof ConfigOptions<StateT, AppStateT, ContextRegistry>>(
+    key: K,
+    val: ConfigOptions<StateT, AppStateT, ContextRegistry>[K],
+  ): void;
 
   /**
    * Executes the route handler matching the given URL fragment, and updates

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -65,7 +65,9 @@ export interface PanelHooks<State> {
 
 // this type is not checked in the Component ContextRegistryT, the Component JS manually checks for these properties instead
 export interface PanelLifecycleContext {
+  // optional callback that executes each time the component is connected to the DOM
   bindToComponent?(component: Component<any>): void;
+  // optional callback that executes each time the component is disconnected from the DOM
   unbindFromComponent?(component: Component<any>): void;
 }
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -266,7 +266,8 @@ export class Component<
   onDisconnected(callback: () => void): void;
 
   /**
-   * Returns the default context of the highest (ie. closest to the document root) ancestor component that has configured a default context for the context name,
+   * Returns the default context of the highest (ie. closest to the document root) ancestor component
+   * that has configured a default context for the context name,
    * or it will return the component's own default context if no ancestor context was found.
    */
   getContext<ContextKey extends keyof ContextRegistryT>(contextName: ContextKey): ContextRegistryT[ContextKey];

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -63,13 +63,13 @@ export interface PanelHooks<State> {
   [hookName: string]: (params: any) => void;
 }
 
-// this type is not checked in the Component ContextRegistry, the Component JS manually checks for these properties instead
+// this type is not checked in the Component ContextRegistryT, the Component JS manually checks for these properties instead
 export interface PanelLifecycleContext {
   bindToComponent?(component: Component<any>): void;
   unbindFromComponent?(component: Component<any>): void;
 }
 
-export interface ConfigOptions<StateT, AppStateT = unknown, ContextRegistry = unknown> {
+export interface ConfigOptions<StateT, AppStateT = unknown, ContextRegistryT = unknown> {
   /** Function transforming state object to virtual dom tree */
   template(scope?: StateT): VNode;
 
@@ -80,10 +80,10 @@ export interface ConfigOptions<StateT, AppStateT = unknown, ContextRegistry = un
   defaultState?: StateT;
 
   /** Default contexts for the component and its descendants to use if no context parent provides them */
-  defaultContexts?: Partial<ContextRegistry>;
+  defaultContexts?: Partial<ContextRegistryT>;
 
   /** Names of contexts for the component to attach and depend upon */
-  contexts?: Array<keyof ContextRegistry>;
+  contexts?: Array<keyof ContextRegistryT>;
 
   /**
    * A state object to share with nested descendant components. If not set, root component
@@ -148,7 +148,7 @@ export class Component<
   AttrsT = AnyAttrs,
   AppStateT = unknown,
   AppT = unknown,
-  ContextRegistry = unknown
+  ContextRegistryT = unknown
 > extends WebComponent {
   /** The first Panel Component ancestor in the DOM tree; null if this component is the root */
   $panelParent: Component<unknown>;
@@ -175,7 +175,7 @@ export class Component<
   state: StateT;
 
   /** Defines standard component configuration */
-  get config(): ConfigOptions<StateT, AppStateT, ContextRegistry>;
+  get config(): ConfigOptions<StateT, AppStateT, ContextRegistryT>;
 
   /**
    * Template helper functions defined in config object, and exposed to template code as $helpers.
@@ -205,12 +205,12 @@ export class Component<
    * Fetches a value from the component's configuration map (a combination of
    * values supplied in the config() getter and defaults applied automatically).
    */
-  getConfig<K extends keyof ConfigOptions<StateT, AppStateT, ContextRegistry>>(key: K): this['config'][K];
+  getConfig<K extends keyof ConfigOptions<StateT, AppStateT, ContextRegistryT>>(key: K): this['config'][K];
 
   /** Sets a value in the component's configuration map after element initialization */
-  setConfig<K extends keyof ConfigOptions<StateT, AppStateT, ContextRegistry>>(
+  setConfig<K extends keyof ConfigOptions<StateT, AppStateT, ContextRegistryT>>(
     key: K,
-    val: ConfigOptions<StateT, AppStateT, ContextRegistry>[K],
+    val: ConfigOptions<StateT, AppStateT, ContextRegistryT>[K],
   ): void;
 
   /**
@@ -221,7 +221,7 @@ export class Component<
 
   /** Run a user-defined hook with the given parameters */
   runHook: (
-    hookName: keyof ConfigOptions<StateT, AppStateT, ContextRegistry>['hooks'],
+    hookName: keyof ConfigOptions<StateT, AppStateT, ContextRegistryT>['hooks'],
     options: {cascade: boolean; exclude: Component<any, any>},
     params: any,
   ) => void;
@@ -265,5 +265,5 @@ export class Component<
    */
   onDisconnected(callback: () => void): void;
 
-  getContext<ContextKey extends keyof ContextRegistry>(contextName: ContextKey): ContextRegistry[ContextKey];
+  getContext<ContextKey extends keyof ContextRegistryT>(contextName: ContextKey): ContextRegistryT[ContextKey];
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -63,12 +63,13 @@ export interface PanelHooks<State> {
   [hookName: string]: (params: any) => void;
 }
 
-export interface PanelContext {
+// this type is not checked in the Component ContextRegistry, the Component JS manually checks for these properties instead
+export interface PanelLifecycleContext {
   attachedCallback?(component: Component<any>): void;
   unattachedCallback?(component: Component<any>): void;
 }
 
-export interface ConfigOptions<StateT, AppStateT = unknown, ContextRegistry extends {[key: string]: PanelContext;} = unknown> {
+export interface ConfigOptions<StateT, AppStateT = unknown, ContextRegistry = unknown> {
   /** Function transforming state object to virtual dom tree */
   template(scope?: StateT): VNode;
 
@@ -198,10 +199,10 @@ export class Component<StateT, AttrsT = AnyAttrs, AppStateT = unknown, AppT = un
    * Fetches a value from the component's configuration map (a combination of
    * values supplied in the config() getter and defaults applied automatically).
    */
-  getConfig<K extends keyof ConfigOptions<StateT, AppStateT>>(key: K): this['config'][K];
+  getConfig<K extends keyof ConfigOptions<StateT, AppStateT, ContextRegistry>>(key: K): this['config'][K];
 
   /** Sets a value in the component's configuration map after element initialization */
-  setConfig<K extends keyof ConfigOptions<StateT, AppStateT>>(key: K, val: ConfigOptions<StateT, AppStateT>[K]): void;
+  setConfig<K extends keyof ConfigOptions<StateT, AppStateT, ContextRegistry>>(key: K, val: ConfigOptions<StateT, AppStateT, ContextRegistry>[K]): void;
 
   /**
    * Executes the route handler matching the given URL fragment, and updates
@@ -211,7 +212,7 @@ export class Component<StateT, AttrsT = AnyAttrs, AppStateT = unknown, AppT = un
 
   /** Run a user-defined hook with the given parameters */
   runHook: (
-    hookName: keyof ConfigOptions<StateT, AppStateT>['hooks'],
+    hookName: keyof ConfigOptions<StateT, AppStateT, ContextRegistry>['hooks'],
     options: {cascade: boolean; exclude: Component<any, any>},
     params: any,
   ) => void;
@@ -255,5 +256,5 @@ export class Component<StateT, AttrsT = AnyAttrs, AppStateT = unknown, AppT = un
    */
   onDisconnected(callback: () => void): void;
 
-  getContext(contextName: keyof ContextRegistry): ContextRegistry[keyof ContextRegistry];
+  getContext<ContextKey extends keyof ContextRegistry>(contextName: ContextKey): ContextRegistry[ContextKey];
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "rm -rf build && babel lib -d build && cp -r build/isorender .",
     "build-test": "webpack --config test/browser/webpack.config.js",
+    "build-test-p": "webpack --config test/browser/webpack.config.js --watch",
     "docs": "rm -rf docs && jsdoc lib lib/component-utils lib/isorender -t node_modules/minami -R README-API.md -d docs",
     "lint": "eslint . && prettier -c \"./**/*.{ts,tsx,js}\" && npm run tslint",
     "prepublishOnly": "npm run build",

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -5,7 +5,6 @@ import {compactHtml} from '../utils';
 import {
   ContextAlpha,
   ContextAlphaImpl,
-  ContextAlphaAltImpl,
   ContextBravo,
   ContextBravoImpl,
 } from '../fixtures/simple-contexts';

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -2,6 +2,7 @@ import {nextAnimationFrame, sleep} from 'domsuite';
 
 import {BreakableApp} from '../fixtures/breakable-app';
 import {compactHtml} from '../utils';
+import {ContextAlpha, ContextAlphaImpl, ContextAlphaAltImpl} from '../fixtures/simple-contexts';
 
 describe(`Simple Component instance`, function () {
   let el;
@@ -841,5 +842,23 @@ describe(`Component with required attrs`, function () {
     await nextAnimationFrame();
 
     expect(el.innerHTML).to.equal(compactHtml(`<div>Shouldn't render with missing attribute!</div>`));
+  });
+});
+
+context(`contexts`, function () {
+  describe(`getContext()`, function () {
+    beforeEach(async function () {
+      document.body.innerHTML = ``;
+      await nextAnimationFrame();
+    });
+
+    it(`returns context of component parent`, function () {
+      const parent = document.createElement(`immediate-context-parent`);
+      document.body.appendChild(parent);
+      const widgetContext = parent.el.querySelector(`context-alpha-widget`).getContext(ContextAlpha);
+      expect(widgetContext).to.be.an.instanceof(ContextAlpha);
+      expect(widgetContext).to.be.an.instanceof(ContextAlphaImpl);
+      expect(widgetContext.getTestName()).to.equal(`immediate-parent-alpha`);
+    });
   });
 });

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -894,7 +894,7 @@ context(`contexts`, function () {
       expect(widgetContext.getTestName()).to.equal(`slotted-alpha`);
     });
 
-    it(`returns context of component grandparent`, function () {
+    it(`returns context of root component while wrapped by a context parent`, function () {
       const parent = document.createElement(`context-grandparent`);
       document.body.appendChild(parent);
       const widgetContext = parent
@@ -906,7 +906,7 @@ context(`contexts`, function () {
       expect(widgetContext.getTestName()).to.equal(`grandparent-alpha`);
     });
 
-    it(`returns different contexts in a widget tree containing multiple contexts`, function () {
+    it(`returns appropriate contexts in a widget tree containing multiple different contexts`, function () {
       const parent = document.createElement(`context-bravo-parent-with-nested-alpha-widgets`);
       document.body.appendChild(parent);
 
@@ -919,6 +919,27 @@ context(`contexts`, function () {
       expect(bravoWidgetContext).to.be.an.instanceof(ContextBravo);
       expect(bravoWidgetContext).to.be.an.instanceof(ContextBravoImpl);
       expect(bravoWidgetContext.getTestName()).to.equal(`parent-bravo`);
+    });
+
+    it(`returns context of root component while wrapped by contextless component`, function () {
+      const parent = document.createElement(`context-parent-with-contextless-component-wrapper`);
+      document.body.appendChild(parent);
+      const widgetContext = parent
+        .el.querySelector(`contextless-component-wrapper`)
+        .el.querySelector(`context-alpha-widget`)
+        .getContext(ContextAlpha);
+      expect(widgetContext).to.be.an.instanceof(ContextAlpha);
+      expect(widgetContext).to.be.an.instanceof(ContextAlphaImpl);
+      expect(widgetContext.getTestName()).to.equal(`parent-alpha`);
+    });
+
+    it(`returns context of root component while slotted in a contextless component`, function () {
+      const parent = document.createElement(`context-parent-with-contextless-slotted-wrapper`);
+      document.body.appendChild(parent);
+      const widgetContext = parent.el.querySelector(`context-alpha-widget`).getContext(ContextAlpha);
+      expect(widgetContext).to.be.an.instanceof(ContextAlpha);
+      expect(widgetContext).to.be.an.instanceof(ContextAlphaImpl);
+      expect(widgetContext.getTestName()).to.equal(`parent-alpha`);
     });
   });
 });

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -2,12 +2,7 @@ import {nextAnimationFrame, sleep} from 'domsuite';
 
 import {BreakableApp} from '../fixtures/breakable-app';
 import {compactHtml} from '../utils';
-import {
-  ContextAlpha,
-  ContextAlphaImpl,
-  ContextBravo,
-  ContextBravoImpl,
-} from '../fixtures/simple-contexts';
+import {ContextAlpha, ContextAlphaImpl, ContextBravo, ContextBravoImpl} from '../fixtures/simple-contexts';
 
 describe(`Simple Component instance`, function () {
   let el;
@@ -896,8 +891,8 @@ context(`contexts`, function () {
     it(`returns context of root component while wrapped by a context parent`, function () {
       const parent = document.createElement(`context-grandparent`);
       document.body.appendChild(parent);
-      const widgetContext = parent
-        .el.querySelector(`immediate-context-parent`)
+      const widgetContext = parent.el
+        .querySelector(`immediate-context-parent`)
         .el.querySelector(`context-alpha-widget`)
         .getContext(ContextAlpha);
       expect(widgetContext).to.be.an.instanceof(ContextAlpha);
@@ -923,8 +918,8 @@ context(`contexts`, function () {
     it(`returns context of root component while wrapped by contextless component`, function () {
       const parent = document.createElement(`context-parent-with-contextless-component-wrapper`);
       document.body.appendChild(parent);
-      const widgetContext = parent
-        .el.querySelector(`contextless-component-wrapper`)
+      const widgetContext = parent.el
+        .querySelector(`contextless-component-wrapper`)
         .el.querySelector(`context-alpha-widget`)
         .getContext(ContextAlpha);
       expect(widgetContext).to.be.an.instanceof(ContextAlpha);

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -977,7 +977,7 @@ context(`Component with contexts`, function () {
       const errors = [];
       window.uncaughtErrorFilter = (errorEvent) => {
         errors.push(errorEvent.message);
-        return errorEvent.message.includes(`context is not available`);
+        return true;
       };
 
       try {
@@ -990,6 +990,8 @@ context(`Component with contexts`, function () {
       await nextAnimationFrame();
 
       expect(errors).to.have.lengthOf(1);
+      expect(errors[0]).to.contain(`context is not available`);
+
       delete window.uncaughtErrorFilter;
     });
 

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -1,4 +1,4 @@
-import {nextAnimationFrame, sleep} from 'domsuite';
+import {condition, nextAnimationFrame, sleep} from 'domsuite';
 
 import {BreakableApp} from '../fixtures/breakable-app';
 import {compactHtml} from '../utils';
@@ -981,9 +981,7 @@ context(`Component with contexts`, function () {
 
       const widget = document.createElement(`themed-widget`);
       document.body.appendChild(widget);
-      await nextAnimationFrame();
-
-      expect(errors).to.have.lengthOf(1);
+      await condition(() => errors.length === 1);
       delete window.uncaughtErrorFilter;
     });
 

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -1019,6 +1019,38 @@ context(`Component with contexts`, function () {
       bindToComponentSpy.restore();
     });
 
+    it(`executes bindToComponent callback each time the same component is repeatedly connected`, async function () {
+      const app = document.createElement(`slotted-load-counter-widget`);
+      const counter = app.getConfig(`defaultContexts`).loadCounter;
+      const bindToComponentSpy = sinon.spy(counter, `bindToComponent`);
+      document.body.appendChild(app);
+      await nextAnimationFrame();
+      expect(counter.getCount()).to.equal(1);
+      expect(bindToComponentSpy.getCall(0).args[0]).to.equal(app);
+
+      const widget = document.createElement(`slotted-load-counter-widget`);
+      app.appendChild(widget);
+      await nextAnimationFrame();
+      expect(counter.getCount()).to.equal(2);
+      expect(bindToComponentSpy.getCall(1).args[0]).to.equal(widget);
+
+      app.removeChild(widget);
+      await nextAnimationFrame();
+      app.appendChild(widget);
+      await nextAnimationFrame();
+      expect(counter.getCount()).to.equal(2);
+      expect(bindToComponentSpy.getCall(2).args[0]).to.equal(widget);
+
+      app.removeChild(widget);
+      await nextAnimationFrame();
+      app.appendChild(widget);
+      await nextAnimationFrame();
+      expect(counter.getCount()).to.equal(2);
+      expect(bindToComponentSpy.getCall(3).args[0]).to.equal(widget);
+
+      bindToComponentSpy.restore();
+    });
+
     it(`executes unbindFromComponent callback when disconnected`, async function () {
       const widget1 = document.createElement(`slotted-load-counter-widget`);
       document.body.appendChild(widget1);
@@ -1048,6 +1080,38 @@ context(`Component with contexts`, function () {
       await nextAnimationFrame();
       expect(counter.getCount()).to.equal(0);
       expect(unbindFromComponentSpy.getCall(2).args[0]).to.equal(widget1);
+
+      unbindFromComponentSpy.restore();
+    });
+
+    it(`executes unbindFromComponent callback each time the same component is repeatedly disconnected`, async function () {
+      const app = document.createElement(`slotted-load-counter-widget`);
+      const counter = app.getConfig(`defaultContexts`).loadCounter;
+      const unbindFromComponentSpy = sinon.spy(counter, `unbindFromComponent`);
+      document.body.appendChild(app);
+      await nextAnimationFrame();
+
+      const widget = document.createElement(`slotted-load-counter-widget`);
+      app.appendChild(widget);
+      await nextAnimationFrame();
+      app.removeChild(widget);
+      await nextAnimationFrame();
+      expect(counter.getCount()).to.equal(1);
+      expect(unbindFromComponentSpy.getCall(0).args[0]).to.equal(widget);
+
+      app.appendChild(widget);
+      await nextAnimationFrame();
+      app.removeChild(widget);
+      await nextAnimationFrame();
+      expect(counter.getCount()).to.equal(1);
+      expect(unbindFromComponentSpy.getCall(1).args[0]).to.equal(widget);
+
+      app.appendChild(widget);
+      await nextAnimationFrame();
+      app.removeChild(widget);
+      await nextAnimationFrame();
+      expect(counter.getCount()).to.equal(1);
+      expect(unbindFromComponentSpy.getCall(2).args[0]).to.equal(widget);
 
       unbindFromComponentSpy.restore();
     });

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -858,6 +858,7 @@ context(`Component with contexts`, function () {
 
       await nextAnimationFrame();
       expect(widget.getContext(`theme`)).to.be.an.instanceof(LightTheme);
+      expect(widget.el.lastElementChild.className).to.equal(`light`);
     });
 
     it(`returns default context from wrapper component`, async function () {
@@ -874,8 +875,9 @@ context(`Component with contexts`, function () {
       document.body.appendChild(darkApp);
 
       await nextAnimationFrame();
-      const theme = darkApp.el.querySelector(`default-light-themed-widget`).getContext(`theme`);
-      expect(theme).to.be.an.instanceof(DarkTheme);
+      const widget = darkApp.el.querySelector(`default-light-themed-widget`);
+      expect(widget.getContext(`theme`)).to.be.an.instanceof(DarkTheme);
+      expect(widget.el.lastElementChild.className).to.equal(`dark`);
     });
 
     it(`returns default context from slotted wrapper component`, async function () {
@@ -887,6 +889,7 @@ context(`Component with contexts`, function () {
 
       await nextAnimationFrame();
       expect(widget.getContext(`theme`)).to.be.an.instanceof(DarkTheme);
+      expect(widget.el.lastElementChild.className).to.equal(`dark`);
     });
 
     it(`returns default context from root component`, async function () {
@@ -901,6 +904,7 @@ context(`Component with contexts`, function () {
 
       await nextAnimationFrame();
       expect(widget.getContext(`theme`)).to.be.an.instanceof(DarkTheme);
+      expect(widget.el.lastElementChild.className).to.equal(`dark`);
     });
 
     it(`returns differently named contexts from different context ancestors`, async function () {
@@ -916,6 +920,7 @@ context(`Component with contexts`, function () {
       await nextAnimationFrame();
       expect(widget.getContext(`theme`)).to.be.an.instanceof(DarkTheme);
       expect(widget.getContext(`invertedTheme`)).to.be.an.instanceof(LightTheme);
+      expect(Array.from(widget.el.lastElementChild.classList)).to.have.members([`light`, `dark`]);
     });
 
     it(`returns same context as other components sharing the same root component`, async function () {
@@ -935,6 +940,9 @@ context(`Component with contexts`, function () {
       expect(widget.getContext(`theme`)).to.be.an.instanceof(DarkTheme);
       expect(widget.getContext(`theme`)).to.equal(siblingWidget.getContext(`theme`));
       expect(widget.getContext(`theme`)).to.equal(nephewWidget.getContext(`theme`));
+      expect(widget.el.lastElementChild.className).to.equal(`dark`);
+      expect(siblingWidget.el.lastElementChild.className).to.equal(`dark`);
+      expect(nephewWidget.el.lastElementChild.className).to.equal(`dark`);
     });
 
     it(`throws error when context name is not declared in config`, async function () {

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -903,7 +903,7 @@ context(`Component with contexts`, function () {
       expect(widget.getContext(`theme`)).to.be.an.instanceof(DarkTheme);
     });
 
-    it(`returns different default context from different context ancestors`, async function () {
+    it(`returns differently named contexts from different context ancestors`, async function () {
       const darkApp = document.createElement(`slotted-dark-app`);
       document.body.appendChild(darkApp);
 

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -2,7 +2,7 @@ import {nextAnimationFrame, sleep} from 'domsuite';
 
 import {BreakableApp} from '../fixtures/breakable-app';
 import {compactHtml} from '../utils';
-import {ContextAlpha, ContextAlphaImpl, ContextBravo, ContextBravoImpl} from '../fixtures/simple-contexts';
+import {LightTheme, DarkTheme} from '../fixtures/simple-contexts';
 
 describe(`Simple Component instance`, function () {
   let el;
@@ -845,95 +845,41 @@ describe(`Component with required attrs`, function () {
   });
 });
 
-context(`contexts`, function () {
+context(`Component with contexts`, function () {
   describe(`getContext()`, function () {
     beforeEach(async function () {
       document.body.innerHTML = ``;
       await nextAnimationFrame();
     });
 
-    it(`returns context of immediate component parent`, function () {
-      const parent = document.createElement(`immediate-context-parent`);
-      document.body.appendChild(parent);
-      const widgetContext = parent.el.querySelector(`context-alpha-widget`).getContext(`alpha`);
-      expect(widgetContext).to.be.an.instanceof(ContextAlpha);
-      expect(widgetContext).to.be.an.instanceof(ContextAlphaImpl);
-      expect(widgetContext.getTestName()).to.equal(`immediate-parent-alpha`);
+    it(`returns own default context without context ancestor`, function () {
+      const widget = document.createElement(`default-light-themed-widget`);
+      document.body.appendChild(widget);
+      const theme = widget.getContext(`theme`);
+      expect(theme).to.be.an.instanceof(LightTheme);
     });
 
-    it(`returns context of immediate component parent with non-panel wrappers`, function () {
-      const parent = document.createElement(`immediate-context-parent-with-wrapper`);
-      document.body.appendChild(parent);
-      const widgetContext = parent.el.querySelector(`context-alpha-widget`).getContext(`alpha`);
-      expect(widgetContext).to.be.an.instanceof(ContextAlpha);
-      expect(widgetContext).to.be.an.instanceof(ContextAlphaImpl);
-      expect(widgetContext.getTestName()).to.equal(`immediate-parent-alpha-with-wrapper`);
+    it(`returns default context from wrapper component`, function () {
+      const darkApp = document.createElement(`dark-app`);
+      document.body.appendChild(darkApp);
+      const theme = darkApp.el.querySelector(`default-light-themed-widget`).getContext(`theme`);
+      expect(theme).to.be.an.instanceof(DarkTheme);
     });
 
-    it(`returns context of shadow DOM component parent`, function () {
-      const parent = document.createElement(`shadow-dom-context-parent`);
-      document.body.appendChild(parent);
-      const widgetContext = parent.el.querySelector(`context-alpha-widget`).getContext(`alpha`);
-      expect(widgetContext).to.be.an.instanceof(ContextAlpha);
-      expect(widgetContext).to.be.an.instanceof(ContextAlphaImpl);
-      expect(widgetContext.getTestName()).to.equal(`shadow-dom-parent-alpha`);
+    it(`returns default context from shadow DOM wrapper component`, function () {
+      const darkApp = document.createElement(`shadow-dom-dark-app`);
+      document.body.appendChild(darkApp);
+      const theme = darkApp.el.querySelector(`default-light-themed-widget`).getContext(`theme`);
+      expect(theme).to.be.an.instanceof(DarkTheme);
     });
 
-    it(`returns context of slotted DOM parent`, function () {
-      const parent = document.createElement(`nested-slotted-context-widgets`);
-      document.body.appendChild(parent);
-      const widgetContext = parent.el.querySelector(`context-alpha-widget`).getContext(`alpha`);
-      expect(widgetContext).to.be.an.instanceof(ContextAlpha);
-      expect(widgetContext).to.be.an.instanceof(ContextAlphaImpl);
-      expect(widgetContext.getTestName()).to.equal(`slotted-alpha`);
-    });
-
-    it(`returns context of root component while wrapped by a context parent`, function () {
-      const parent = document.createElement(`context-grandparent`);
-      document.body.appendChild(parent);
-      const widgetContext = parent.el
-        .querySelector(`immediate-context-parent`)
-        .el.querySelector(`context-alpha-widget`)
-        .getContext(`alpha`);
-      expect(widgetContext).to.be.an.instanceof(ContextAlpha);
-      expect(widgetContext).to.be.an.instanceof(ContextAlphaImpl);
-      expect(widgetContext.getTestName()).to.equal(`grandparent-alpha`);
-    });
-
-    it(`returns appropriate contexts in a widget tree containing multiple different contexts`, function () {
-      const parent = document.createElement(`context-bravo-parent-with-nested-alpha-widgets`);
-      document.body.appendChild(parent);
-
-      const alphaWidgetContext = parent.el.querySelector(`context-alpha-widget`).getContext(`alpha`);
-      expect(alphaWidgetContext).to.be.an.instanceof(ContextAlpha);
-      expect(alphaWidgetContext).to.be.an.instanceof(ContextAlphaImpl);
-      expect(alphaWidgetContext.getTestName()).to.equal(`slotted-alpha`);
-
-      const bravoWidgetContext = parent.el.querySelector(`context-bravo-widget`).getContext(`bravo`);
-      expect(bravoWidgetContext).to.be.an.instanceof(ContextBravo);
-      expect(bravoWidgetContext).to.be.an.instanceof(ContextBravoImpl);
-      expect(bravoWidgetContext.getTestName()).to.equal(`parent-bravo`);
-    });
-
-    it(`returns context of root component while wrapped by contextless component`, function () {
-      const parent = document.createElement(`context-parent-with-contextless-component-wrapper`);
-      document.body.appendChild(parent);
-      const widgetContext = parent.el
-        .querySelector(`contextless-component-wrapper`)
-        .el.querySelector(`context-alpha-widget`)
-        .getContext(`alpha`);
-      expect(widgetContext).to.be.an.instanceof(ContextAlpha);
-      expect(widgetContext).to.be.an.instanceof(ContextAlphaImpl);
-      expect(widgetContext.getTestName()).to.equal(`parent-alpha`);
-    });
-
-    it(`returns context of root component while slotted in a contextless component`, function () {
-      const parent = document.createElement(`context-parent-with-contextless-slotted-wrapper`);
-      document.body.appendChild(parent);
-      const widgetContext = parent.el.querySelector(`context-alpha-widget`).getContext(`alpha`);
-      expect(widgetContext).to.be.an.instanceof(ContextAlpha);
-      expect(widgetContext).to.be.an.instanceof(ContextAlphaImpl);
-      expect(widgetContext.getTestName()).to.equal(`parent-alpha`);
+    it(`returns default context from slotted wrapper component`, function () {
+      const darkApp = document.createElement(`slotted-dark-app`);
+      document.body.appendChild(darkApp);
+      const widget = document.createElement(`default-light-themed-widget`);
+      darkApp.appendChild(widget);
+      const theme = widget.getContext(`theme`);
+      expect(theme).to.be.an.instanceof(DarkTheme);
     });
   });
 });

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -990,7 +990,7 @@ context(`Component with contexts`, function () {
       await nextAnimationFrame();
 
       expect(errors).to.have.lengthOf(1);
-      expect(errors[0]).to.contain(`context is not available`);
+      expect(errors[0]).to.contain(`A "theme" context is not available`);
 
       delete window.uncaughtErrorFilter;
     });

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -2,7 +2,13 @@ import {nextAnimationFrame, sleep} from 'domsuite';
 
 import {BreakableApp} from '../fixtures/breakable-app';
 import {compactHtml} from '../utils';
-import {ContextAlpha, ContextAlphaImpl, ContextAlphaAltImpl} from '../fixtures/simple-contexts';
+import {
+  ContextAlpha,
+  ContextAlphaImpl,
+  ContextAlphaAltImpl,
+  ContextBravo,
+  ContextBravoImpl,
+} from '../fixtures/simple-contexts';
 
 describe(`Simple Component instance`, function () {
   let el;
@@ -852,13 +858,67 @@ context(`contexts`, function () {
       await nextAnimationFrame();
     });
 
-    it(`returns context of component parent`, function () {
+    it(`returns context of immediate component parent`, function () {
       const parent = document.createElement(`immediate-context-parent`);
       document.body.appendChild(parent);
       const widgetContext = parent.el.querySelector(`context-alpha-widget`).getContext(ContextAlpha);
       expect(widgetContext).to.be.an.instanceof(ContextAlpha);
       expect(widgetContext).to.be.an.instanceof(ContextAlphaImpl);
       expect(widgetContext.getTestName()).to.equal(`immediate-parent-alpha`);
+    });
+
+    it(`returns context of immediate component parent with non-panel wrappers`, function () {
+      const parent = document.createElement(`immediate-context-parent-with-wrapper`);
+      document.body.appendChild(parent);
+      const widgetContext = parent.el.querySelector(`context-alpha-widget`).getContext(ContextAlpha);
+      expect(widgetContext).to.be.an.instanceof(ContextAlpha);
+      expect(widgetContext).to.be.an.instanceof(ContextAlphaImpl);
+      expect(widgetContext.getTestName()).to.equal(`immediate-parent-alpha-with-wrapper`);
+    });
+
+    it(`returns context of shadow DOM component parent`, function () {
+      const parent = document.createElement(`shadow-dom-context-parent`);
+      document.body.appendChild(parent);
+      const widgetContext = parent.el.querySelector(`context-alpha-widget`).getContext(ContextAlpha);
+      expect(widgetContext).to.be.an.instanceof(ContextAlpha);
+      expect(widgetContext).to.be.an.instanceof(ContextAlphaImpl);
+      expect(widgetContext.getTestName()).to.equal(`shadow-dom-parent-alpha`);
+    });
+
+    it(`returns context of slotted DOM parent`, function () {
+      const parent = document.createElement(`nested-slotted-context-widgets`);
+      document.body.appendChild(parent);
+      const widgetContext = parent.el.querySelector(`context-alpha-widget`).getContext(ContextAlpha);
+      expect(widgetContext).to.be.an.instanceof(ContextAlpha);
+      expect(widgetContext).to.be.an.instanceof(ContextAlphaImpl);
+      expect(widgetContext.getTestName()).to.equal(`slotted-alpha`);
+    });
+
+    it(`returns context of component grandparent`, function () {
+      const parent = document.createElement(`context-grandparent`);
+      document.body.appendChild(parent);
+      const widgetContext = parent
+        .el.querySelector(`immediate-context-parent`)
+        .el.querySelector(`context-alpha-widget`)
+        .getContext(ContextAlpha);
+      expect(widgetContext).to.be.an.instanceof(ContextAlpha);
+      expect(widgetContext).to.be.an.instanceof(ContextAlphaImpl);
+      expect(widgetContext.getTestName()).to.equal(`grandparent-alpha`);
+    });
+
+    it(`returns different contexts in a widget tree containing multiple contexts`, function () {
+      const parent = document.createElement(`context-bravo-parent-with-nested-alpha-widgets`);
+      document.body.appendChild(parent);
+
+      const alphaWidgetContext = parent.el.querySelector(`context-alpha-widget`).getContext(ContextAlpha);
+      expect(alphaWidgetContext).to.be.an.instanceof(ContextAlpha);
+      expect(alphaWidgetContext).to.be.an.instanceof(ContextAlphaImpl);
+      expect(alphaWidgetContext.getTestName()).to.equal(`slotted-alpha`);
+
+      const bravoWidgetContext = parent.el.querySelector(`context-bravo-widget`).getContext(ContextBravo);
+      expect(bravoWidgetContext).to.be.an.instanceof(ContextBravo);
+      expect(bravoWidgetContext).to.be.an.instanceof(ContextBravoImpl);
+      expect(bravoWidgetContext.getTestName()).to.equal(`parent-bravo`);
     });
   });
 });

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -1010,18 +1010,21 @@ context(`Component with contexts`, function () {
       document.body.appendChild(widget1);
       await nextAnimationFrame();
       expect(counter.getCount()).to.equal(1);
+      expect(bindToComponentSpy).to.have.callCount(1);
       expect(bindToComponentSpy.getCall(0).args[0]).to.equal(widget1);
 
       const widget2 = document.createElement(`slotted-load-counter-widget`);
       widget1.appendChild(widget2);
       await nextAnimationFrame();
       expect(counter.getCount()).to.equal(2);
+      expect(bindToComponentSpy).to.have.callCount(2);
       expect(bindToComponentSpy.getCall(1).args[0]).to.equal(widget2);
 
       const widget3 = document.createElement(`slotted-load-counter-widget`);
       widget2.appendChild(widget3);
       await nextAnimationFrame();
       expect(counter.getCount()).to.equal(3);
+      expect(bindToComponentSpy).to.have.callCount(3);
       expect(bindToComponentSpy.getCall(2).args[0]).to.equal(widget3);
 
       bindToComponentSpy.restore();
@@ -1034,12 +1037,14 @@ context(`Component with contexts`, function () {
       document.body.appendChild(app);
       await nextAnimationFrame();
       expect(counter.getCount()).to.equal(1);
+      expect(bindToComponentSpy).to.have.callCount(1);
       expect(bindToComponentSpy.getCall(0).args[0]).to.equal(app);
 
       const widget = document.createElement(`slotted-load-counter-widget`);
       app.appendChild(widget);
       await nextAnimationFrame();
       expect(counter.getCount()).to.equal(2);
+      expect(bindToComponentSpy).to.have.callCount(2);
       expect(bindToComponentSpy.getCall(1).args[0]).to.equal(widget);
 
       app.removeChild(widget);
@@ -1047,6 +1052,7 @@ context(`Component with contexts`, function () {
       app.appendChild(widget);
       await nextAnimationFrame();
       expect(counter.getCount()).to.equal(2);
+      expect(bindToComponentSpy).to.have.callCount(3);
       expect(bindToComponentSpy.getCall(2).args[0]).to.equal(widget);
 
       app.removeChild(widget);
@@ -1054,6 +1060,7 @@ context(`Component with contexts`, function () {
       app.appendChild(widget);
       await nextAnimationFrame();
       expect(counter.getCount()).to.equal(2);
+      expect(bindToComponentSpy).to.have.callCount(4);
       expect(bindToComponentSpy.getCall(3).args[0]).to.equal(widget);
 
       bindToComponentSpy.restore();
@@ -1077,16 +1084,19 @@ context(`Component with contexts`, function () {
       widget3.remove();
       await nextAnimationFrame();
       expect(counter.getCount()).to.equal(2);
+      expect(unbindFromComponentSpy).to.have.callCount(1);
       expect(unbindFromComponentSpy.getCall(0).args[0]).to.equal(widget3);
 
       widget2.remove();
       await nextAnimationFrame();
       expect(counter.getCount()).to.equal(1);
+      expect(unbindFromComponentSpy).to.have.callCount(2);
       expect(unbindFromComponentSpy.getCall(1).args[0]).to.equal(widget2);
 
       widget1.remove();
       await nextAnimationFrame();
       expect(counter.getCount()).to.equal(0);
+      expect(unbindFromComponentSpy).to.have.callCount(3);
       expect(unbindFromComponentSpy.getCall(2).args[0]).to.equal(widget1);
 
       unbindFromComponentSpy.restore();
@@ -1105,6 +1115,7 @@ context(`Component with contexts`, function () {
       app.removeChild(widget);
       await nextAnimationFrame();
       expect(counter.getCount()).to.equal(1);
+      expect(unbindFromComponentSpy).to.have.callCount(1);
       expect(unbindFromComponentSpy.getCall(0).args[0]).to.equal(widget);
 
       app.appendChild(widget);
@@ -1112,6 +1123,7 @@ context(`Component with contexts`, function () {
       app.removeChild(widget);
       await nextAnimationFrame();
       expect(counter.getCount()).to.equal(1);
+      expect(unbindFromComponentSpy).to.have.callCount(2);
       expect(unbindFromComponentSpy.getCall(1).args[0]).to.equal(widget);
 
       app.appendChild(widget);
@@ -1119,6 +1131,7 @@ context(`Component with contexts`, function () {
       app.removeChild(widget);
       await nextAnimationFrame();
       expect(counter.getCount()).to.equal(1);
+      expect(unbindFromComponentSpy).to.have.callCount(3);
       expect(unbindFromComponentSpy.getCall(2).args[0]).to.equal(widget);
 
       unbindFromComponentSpy.restore();

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -989,19 +989,26 @@ context(`Component with contexts`, function () {
 
     it(`executes bindToComponent callback when connected`, async function () {
       const widget1 = document.createElement(`slotted-load-counter-widget`);
+      const counter = widget1.getConfig(`defaultContexts`).loadCounter;
+      const bindToComponentSpy = sinon.spy(counter, `bindToComponent`);
       document.body.appendChild(widget1);
       await nextAnimationFrame();
-      expect(widget1.getContext(`loadCounter`).getCount()).to.equal(1);
+      expect(counter.getCount()).to.equal(1);
+      expect(bindToComponentSpy.getCall(0).args[0]).to.equal(widget1);
 
       const widget2 = document.createElement(`slotted-load-counter-widget`);
       widget1.appendChild(widget2);
       await nextAnimationFrame();
-      expect(widget1.getContext(`loadCounter`).getCount()).to.equal(2);
+      expect(counter.getCount()).to.equal(2);
+      expect(bindToComponentSpy.getCall(1).args[0]).to.equal(widget2);
 
       const widget3 = document.createElement(`slotted-load-counter-widget`);
       widget2.appendChild(widget3);
       await nextAnimationFrame();
-      expect(widget1.getContext(`loadCounter`).getCount()).to.equal(3);
+      expect(counter.getCount()).to.equal(3);
+      expect(bindToComponentSpy.getCall(2).args[0]).to.equal(widget3);
+
+      bindToComponentSpy.restore();
     });
 
     it(`executes unbindFromComponent callback when disconnected`, async function () {
@@ -1016,19 +1023,23 @@ context(`Component with contexts`, function () {
 
       await nextAnimationFrame();
       const counter = widget1.getContext(`loadCounter`);
+      const unbindFromComponentSpy = sinon.spy(counter, `unbindFromComponent`);
       expect(counter.getCount()).to.equal(3);
 
       widget3.remove();
       await nextAnimationFrame();
       expect(counter.getCount()).to.equal(2);
+      expect(unbindFromComponentSpy.getCall(0).args[0]).to.equal(widget3);
 
       widget2.remove();
       await nextAnimationFrame();
       expect(counter.getCount()).to.equal(1);
+      expect(unbindFromComponentSpy.getCall(1).args[0]).to.equal(widget2);
 
       widget1.remove();
       await nextAnimationFrame();
       expect(counter.getCount()).to.equal(0);
+      expect(unbindFromComponentSpy.getCall(2).args[0]).to.equal(widget1);
     });
   });
 });

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -855,7 +855,7 @@ context(`contexts`, function () {
     it(`returns context of immediate component parent`, function () {
       const parent = document.createElement(`immediate-context-parent`);
       document.body.appendChild(parent);
-      const widgetContext = parent.el.querySelector(`context-alpha-widget`).getContext(ContextAlpha);
+      const widgetContext = parent.el.querySelector(`context-alpha-widget`).getContext(`alpha`);
       expect(widgetContext).to.be.an.instanceof(ContextAlpha);
       expect(widgetContext).to.be.an.instanceof(ContextAlphaImpl);
       expect(widgetContext.getTestName()).to.equal(`immediate-parent-alpha`);
@@ -864,7 +864,7 @@ context(`contexts`, function () {
     it(`returns context of immediate component parent with non-panel wrappers`, function () {
       const parent = document.createElement(`immediate-context-parent-with-wrapper`);
       document.body.appendChild(parent);
-      const widgetContext = parent.el.querySelector(`context-alpha-widget`).getContext(ContextAlpha);
+      const widgetContext = parent.el.querySelector(`context-alpha-widget`).getContext(`alpha`);
       expect(widgetContext).to.be.an.instanceof(ContextAlpha);
       expect(widgetContext).to.be.an.instanceof(ContextAlphaImpl);
       expect(widgetContext.getTestName()).to.equal(`immediate-parent-alpha-with-wrapper`);
@@ -873,7 +873,7 @@ context(`contexts`, function () {
     it(`returns context of shadow DOM component parent`, function () {
       const parent = document.createElement(`shadow-dom-context-parent`);
       document.body.appendChild(parent);
-      const widgetContext = parent.el.querySelector(`context-alpha-widget`).getContext(ContextAlpha);
+      const widgetContext = parent.el.querySelector(`context-alpha-widget`).getContext(`alpha`);
       expect(widgetContext).to.be.an.instanceof(ContextAlpha);
       expect(widgetContext).to.be.an.instanceof(ContextAlphaImpl);
       expect(widgetContext.getTestName()).to.equal(`shadow-dom-parent-alpha`);
@@ -882,7 +882,7 @@ context(`contexts`, function () {
     it(`returns context of slotted DOM parent`, function () {
       const parent = document.createElement(`nested-slotted-context-widgets`);
       document.body.appendChild(parent);
-      const widgetContext = parent.el.querySelector(`context-alpha-widget`).getContext(ContextAlpha);
+      const widgetContext = parent.el.querySelector(`context-alpha-widget`).getContext(`alpha`);
       expect(widgetContext).to.be.an.instanceof(ContextAlpha);
       expect(widgetContext).to.be.an.instanceof(ContextAlphaImpl);
       expect(widgetContext.getTestName()).to.equal(`slotted-alpha`);
@@ -894,7 +894,7 @@ context(`contexts`, function () {
       const widgetContext = parent.el
         .querySelector(`immediate-context-parent`)
         .el.querySelector(`context-alpha-widget`)
-        .getContext(ContextAlpha);
+        .getContext(`alpha`);
       expect(widgetContext).to.be.an.instanceof(ContextAlpha);
       expect(widgetContext).to.be.an.instanceof(ContextAlphaImpl);
       expect(widgetContext.getTestName()).to.equal(`grandparent-alpha`);
@@ -904,12 +904,12 @@ context(`contexts`, function () {
       const parent = document.createElement(`context-bravo-parent-with-nested-alpha-widgets`);
       document.body.appendChild(parent);
 
-      const alphaWidgetContext = parent.el.querySelector(`context-alpha-widget`).getContext(ContextAlpha);
+      const alphaWidgetContext = parent.el.querySelector(`context-alpha-widget`).getContext(`alpha`);
       expect(alphaWidgetContext).to.be.an.instanceof(ContextAlpha);
       expect(alphaWidgetContext).to.be.an.instanceof(ContextAlphaImpl);
       expect(alphaWidgetContext.getTestName()).to.equal(`slotted-alpha`);
 
-      const bravoWidgetContext = parent.el.querySelector(`context-bravo-widget`).getContext(ContextBravo);
+      const bravoWidgetContext = parent.el.querySelector(`context-bravo-widget`).getContext(`bravo`);
       expect(bravoWidgetContext).to.be.an.instanceof(ContextBravo);
       expect(bravoWidgetContext).to.be.an.instanceof(ContextBravoImpl);
       expect(bravoWidgetContext.getTestName()).to.equal(`parent-bravo`);
@@ -921,7 +921,7 @@ context(`contexts`, function () {
       const widgetContext = parent.el
         .querySelector(`contextless-component-wrapper`)
         .el.querySelector(`context-alpha-widget`)
-        .getContext(ContextAlpha);
+        .getContext(`alpha`);
       expect(widgetContext).to.be.an.instanceof(ContextAlpha);
       expect(widgetContext).to.be.an.instanceof(ContextAlphaImpl);
       expect(widgetContext.getTestName()).to.equal(`parent-alpha`);
@@ -930,7 +930,7 @@ context(`contexts`, function () {
     it(`returns context of root component while slotted in a contextless component`, function () {
       const parent = document.createElement(`context-parent-with-contextless-slotted-wrapper`);
       document.body.appendChild(parent);
-      const widgetContext = parent.el.querySelector(`context-alpha-widget`).getContext(ContextAlpha);
+      const widgetContext = parent.el.querySelector(`context-alpha-widget`).getContext(`alpha`);
       expect(widgetContext).to.be.an.instanceof(ContextAlpha);
       expect(widgetContext).to.be.an.instanceof(ContextAlphaImpl);
       expect(widgetContext.getTestName()).to.equal(`parent-alpha`);

--- a/test/fixtures/context-app.d.ts
+++ b/test/fixtures/context-app.d.ts
@@ -7,11 +7,8 @@ interface TestContextRegistry {
 }
 
 export class ContextAlphaWidget extends Component<any, any, any, any, TestContextRegistry> {
-  config: ConfigOptions<
-    any,
-    any,
-    {
-      alpha: ContextAlphaImpl;
-    }
-  >;
+  config: {
+    template: any;
+    attachedContexts: ['alpha'];
+  };
 }

--- a/test/fixtures/context-app.d.ts
+++ b/test/fixtures/context-app.d.ts
@@ -7,7 +7,11 @@ interface TestContextRegistry {
 }
 
 export class ContextAlphaWidget extends Component<any, any, any, any, TestContextRegistry> {
-  config: ConfigOptions<any, any, {
-    alpha: ContextAlphaImpl;
-  }>;
+  config: ConfigOptions<
+    any,
+    any,
+    {
+      alpha: ContextAlphaImpl;
+    }
+  >;
 }

--- a/test/fixtures/context-app.d.ts
+++ b/test/fixtures/context-app.d.ts
@@ -1,0 +1,13 @@
+import {Component, ConfigOptions} from '../../lib';
+import {ContextAlpha, ContextAlphaImpl, ContextBravo} from './simple-contexts';
+
+interface TestContextRegistry {
+  alpha: ContextAlpha;
+  bravo: ContextBravo;
+}
+
+export class ContextAlphaWidget extends Component<any, any, any, any, TestContextRegistry> {
+  config: ConfigOptions<any, any, {
+    alpha: ContextAlphaImpl;
+  }>;
+}

--- a/test/fixtures/context-app.d.ts
+++ b/test/fixtures/context-app.d.ts
@@ -1,14 +1,54 @@
 import {Component, ConfigOptions} from '../../lib';
-import {ContextAlpha, ContextAlphaImpl, ContextBravo} from './simple-contexts';
+import {Theme, LightTheme, DarkTheme, LoadCounter} from './simple-contexts';
 
 interface TestContextRegistry {
-  alpha: ContextAlpha;
-  bravo: ContextBravo;
+  theme: Theme;
+  energySavingTheme: Theme;
+  loadCounter: LoadCounter;
 }
 
-export class ContextAlphaWidget extends Component<any, any, any, any, TestContextRegistry> {
-  config: {
+export class DefaultLightThemedWidget extends Component<any, any, any, any, TestContextRegistry> {
+  get config(): {
     template: any;
-    attachedContexts: ['alpha'];
+    contexts: ['theme'];
+    defaultContexts: {
+      theme: LightTheme;
+    };
+  };
+}
+
+export class ThemedWidget extends Component<any, any, any, any, TestContextRegistry> {
+  get config(): {
+    template: any;
+    contexts: ['theme'];
+  };
+}
+
+export class DarkApp extends Component<any, any, any, any, TestContextRegistry> {
+  get config(): {
+    template: any;
+    defaultContexts: {
+      theme: DarkTheme;
+    };
+  };
+}
+
+export class ShadowDomDarkApp extends Component<any, any, any, any, TestContextRegistry> {
+  get config(): {
+    template: any;
+    defaultContexts: {
+      theme: DarkTheme;
+    };
+    useShadowDom: boolean;
+  };
+}
+
+export class SlottedDarkApp extends Component<any, any, any, any, TestContextRegistry> {
+  get config(): {
+    template: any;
+    defaultContexts: {
+      theme: DarkTheme;
+    };
+    useShadowDom: boolean;
   };
 }

--- a/test/fixtures/context-app.d.ts
+++ b/test/fixtures/context-app.d.ts
@@ -3,7 +3,7 @@ import {Theme, LightTheme, DarkTheme, LoadCounter} from './simple-contexts';
 
 interface TestContextRegistry {
   theme: Theme;
-  energySavingTheme: Theme;
+  invertedTheme: Theme;
   loadCounter: LoadCounter;
 }
 
@@ -21,6 +21,13 @@ export class ThemedWidget extends Component<any, any, any, any, TestContextRegis
   get config(): {
     template: any;
     contexts: ['theme'];
+  };
+}
+
+export class MultiThemedWidget extends Component<any, any, any, any, TestContextRegistry> {
+  get config(): {
+    template: any;
+    contexts: ['theme', 'invertedTheme'];
   };
 }
 
@@ -48,6 +55,38 @@ export class SlottedDarkApp extends Component<any, any, any, any, TestContextReg
     template: any;
     defaultContexts: {
       theme: DarkTheme;
+    };
+    useShadowDom: boolean;
+  };
+}
+
+export class SlottedLightApp extends Component<any, any, any, any, TestContextRegistry> {
+  get config(): {
+    template: any;
+    contexts: ['theme'];
+    defaultContexts: {
+      theme: LightTheme;
+    };
+    useShadowDom: boolean;
+  };
+}
+
+export class SlottedInvertedLightApp extends Component<any, any, any, any, TestContextRegistry> {
+  get config(): {
+    template: any;
+    defaultContexts: {
+      invertedTheme: LightTheme;
+    };
+    useShadowDom: boolean;
+  };
+}
+
+export class SlottedLoadCounterWidget extends Component<any, any, any, any, TestContextRegistry> {
+  get config(): {
+    template: any;
+    contexts: ['loadCounter'];
+    defaultContexts: {
+      loadCounter: LoadCounter;
     };
     useShadowDom: boolean;
   };

--- a/test/fixtures/context-app.js
+++ b/test/fixtures/context-app.js
@@ -1,20 +1,11 @@
 import {Component, h} from '../../lib';
-import {
-  ContextAlpha,
-  ContextAlphaImpl,
-  ContextAlphaAltImpl,
-  ContextBravo,
-  ContextBravoImpl,
-} from './simple-contexts';
+import {ContextAlpha, ContextAlphaImpl, ContextAlphaAltImpl, ContextBravo, ContextBravoImpl} from './simple-contexts';
 
 export class ContextAlphaWidget extends Component {
   get config() {
     return {
-      template: () =>
-        h(`div`, {class: {foo: true}}),
-      defaultContexts: new Map([
-        [ContextAlpha, new ContextAlphaImpl(`default-alpha`)],
-      ]),
+      template: () => h(`div`, {class: {foo: true}}),
+      defaultContexts: new Map([[ContextAlpha, new ContextAlphaImpl(`default-alpha`)]]),
     };
   }
 }
@@ -22,11 +13,8 @@ export class ContextAlphaWidget extends Component {
 export class ImmediateContextParent extends Component {
   get config() {
     return {
-      template: () =>
-        h(`context-alpha-widget`, {class: {foo: true}}),
-      defaultContexts: new Map([
-        [ContextAlpha, new ContextAlphaImpl(`immediate-parent-alpha`)],
-      ]),
+      template: () => h(`context-alpha-widget`, {class: {foo: true}}),
+      defaultContexts: new Map([[ContextAlpha, new ContextAlphaImpl(`immediate-parent-alpha`)]]),
     };
   }
 }
@@ -37,17 +25,10 @@ export class ImmediateContextParentWithWrapper extends Component {
       template: () =>
         h(`div`, {class: {foo: true}}, [
           h(`p`, `asdf`),
-          h(`div`, {class: {foo: true}}, [
-            h(`div`, {class: {foo: true}}, [
-              h(`context-alpha-widget`),
-            ]),
-            h(`p`, `asdf`),
-          ]),
+          h(`div`, {class: {foo: true}}, [h(`div`, {class: {foo: true}}, [h(`context-alpha-widget`)]), h(`p`, `asdf`)]),
           h(`p`, `asdf`),
         ]),
-      defaultContexts: new Map([
-        [ContextAlpha, new ContextAlphaImpl(`immediate-parent-alpha-with-wrapper`)],
-      ]),
+      defaultContexts: new Map([[ContextAlpha, new ContextAlphaImpl(`immediate-parent-alpha-with-wrapper`)]]),
     };
   }
 }
@@ -58,17 +39,10 @@ export class ShadowDomContextParent extends Component {
       template: () =>
         h(`div`, {class: {foo: true}}, [
           h(`p`, `asdf`),
-          h(`div`, {class: {foo: true}}, [
-            h(`div`, {class: {foo: true}}, [
-              h(`context-alpha-widget`),
-            ]),
-            h(`p`, `asdf`),
-          ]),
+          h(`div`, {class: {foo: true}}, [h(`div`, {class: {foo: true}}, [h(`context-alpha-widget`)]), h(`p`, `asdf`)]),
           h(`p`, `asdf`),
         ]),
-      defaultContexts: new Map([
-        [ContextAlpha, new ContextAlphaImpl(`shadow-dom-parent-alpha`)],
-      ]),
+      defaultContexts: new Map([[ContextAlpha, new ContextAlphaImpl(`shadow-dom-parent-alpha`)]]),
       useShadowDom: true,
     };
   }
@@ -77,11 +51,8 @@ export class ShadowDomContextParent extends Component {
 export class ContextAlphaSlottedWidget extends Component {
   get config() {
     return {
-      template: () =>
-        h(`slot`),
-      defaultContexts: new Map([
-        [ContextAlpha, new ContextAlphaImpl(`slotted-alpha`)],
-      ]),
+      template: () => h(`slot`),
+      defaultContexts: new Map([[ContextAlpha, new ContextAlphaImpl(`slotted-alpha`)]]),
     };
   }
 }
@@ -89,11 +60,8 @@ export class ContextAlphaSlottedWidget extends Component {
 export class ContextAlphaAltSlottedWidget extends Component {
   get config() {
     return {
-      template: () =>
-        h(`slot`),
-      defaultContexts: new Map([
-        [ContextAlpha, new ContextAlphaAltImpl()],
-      ]),
+      template: () => h(`slot`),
+      defaultContexts: new Map([[ContextAlpha, new ContextAlphaAltImpl()]]),
     };
   }
 }
@@ -106,9 +74,7 @@ export class NestedSlottedContextWidgets extends Component {
           h(`p`, `asdf`),
           h(`context-alpha-slotted-widget`, {class: {foo: true}}, [
             h(`span`, {class: {foo: true}}, [
-              h(`context-alpha-alt-slotted-widget`, {class: {foo: true}}, [
-                h(`context-alpha-widget`),
-              ]),
+              h(`context-alpha-alt-slotted-widget`, {class: {foo: true}}, [h(`context-alpha-widget`)]),
             ]),
             h(`p`, `asdf`),
           ]),
@@ -121,11 +87,8 @@ export class NestedSlottedContextWidgets extends Component {
 export class ContextGrandparent extends Component {
   get config() {
     return {
-      template: () =>
-        h(`immediate-context-parent`, {class: {foo: true}}),
-      defaultContexts: new Map([
-        [ContextAlpha, new ContextAlphaImpl(`grandparent-alpha`)],
-      ]),
+      template: () => h(`immediate-context-parent`, {class: {foo: true}}),
+      defaultContexts: new Map([[ContextAlpha, new ContextAlphaImpl(`grandparent-alpha`)]]),
     };
   }
 }
@@ -133,11 +96,8 @@ export class ContextGrandparent extends Component {
 export class ContextBravoWidget extends Component {
   get config() {
     return {
-      template: () =>
-        h(`div`, {class: {foo: true}}),
-      defaultContexts: new Map([
-        [ContextBravo, new ContextBravoImpl(`default-bravo`)],
-      ]),
+      template: () => h(`div`, {class: {foo: true}}),
+      defaultContexts: new Map([[ContextBravo, new ContextBravoImpl(`default-bravo`)]]),
     };
   }
 }
@@ -159,9 +119,7 @@ export class ContextBravoParentWithNestedAlphaWidgets extends Component {
           ]),
           h(`p`, `asdf`),
         ]),
-      defaultContexts: new Map([
-        [ContextBravo, new ContextBravoImpl(`parent-bravo`)],
-      ]),
+      defaultContexts: new Map([[ContextBravo, new ContextBravoImpl(`parent-bravo`)]]),
     };
   }
 }
@@ -169,8 +127,7 @@ export class ContextBravoParentWithNestedAlphaWidgets extends Component {
 export class ContextlessSlottedWrapper extends Component {
   get config() {
     return {
-      template: () =>
-        h(`slot`),
+      template: () => h(`slot`),
     };
   }
 }
@@ -181,14 +138,10 @@ export class ContextParentWithContextlessSlottedWrapper extends Component {
       template: () =>
         h(`div`, {class: {foo: true}}, [
           h(`p`, `asdf`),
-          h(`contextless-slotted-wrapper`, {class: {foo: true}}, [
-            h(`context-alpha-widget`),
-          ]),
+          h(`contextless-slotted-wrapper`, {class: {foo: true}}, [h(`context-alpha-widget`)]),
           h(`p`, `asdf`),
         ]),
-      defaultContexts: new Map([
-        [ContextAlpha, new ContextAlphaImpl(`parent-alpha`)],
-      ]),
+      defaultContexts: new Map([[ContextAlpha, new ContextAlphaImpl(`parent-alpha`)]]),
     };
   }
 }
@@ -196,8 +149,7 @@ export class ContextParentWithContextlessSlottedWrapper extends Component {
 export class ContextlessComponentWrapper extends Component {
   get config() {
     return {
-      template: () =>
-        h(`context-alpha-widget`),
+      template: () => h(`context-alpha-widget`),
     };
   }
 }
@@ -205,13 +157,8 @@ export class ContextlessComponentWrapper extends Component {
 export class ContextParentWithContextlessComponentWrapper extends Component {
   get config() {
     return {
-      template: () =>
-        h(`div`, {class: {foo: true}}, [
-          h(`contextless-component-wrapper`),
-        ]),
-      defaultContexts: new Map([
-        [ContextAlpha, new ContextAlphaImpl(`parent-alpha`)],
-      ]),
+      template: () => h(`div`, {class: {foo: true}}, [h(`contextless-component-wrapper`)]),
+      defaultContexts: new Map([[ContextAlpha, new ContextAlphaImpl(`parent-alpha`)]]),
     };
   }
 }

--- a/test/fixtures/context-app.js
+++ b/test/fixtures/context-app.js
@@ -5,7 +5,7 @@ export class ContextAlphaWidget extends Component {
   get config() {
     return {
       template: () => h(`div`, {class: {foo: true}}),
-      defaultContexts: {alpha: new ContextAlphaImpl(`default-alpha`)},
+      attachedContexts: [`alpha`],
     };
   }
 }
@@ -97,7 +97,7 @@ export class ContextBravoWidget extends Component {
   get config() {
     return {
       template: () => h(`div`, {class: {foo: true}}),
-      defaultContexts: {bravo: new ContextBravoImpl(`default-bravo`)},
+      attachedContexts: [`bravo`],
     };
   }
 }

--- a/test/fixtures/context-app.js
+++ b/test/fixtures/context-app.js
@@ -1,0 +1,26 @@
+import {Component, h} from '../../lib';
+import {ContextAlpha, ContextAlphaImpl, ContextAlphaAltImpl} from './simple-contexts';
+
+export class ContextAlphaWidget extends Component {
+  get config() {
+    return {
+      template: (state) =>
+        h(`div`, {class: {foo: true}}),
+      defaultContexts: new Map([
+        [ContextAlpha, new ContextAlphaImpl(`default-alpha`)],
+      ]),
+    };
+  }
+}
+
+export class ImmediateContextParent extends Component {
+  get config() {
+    return {
+      template: (state) =>
+        h(`context-alpha-widget`, {class: {foo: true}}),
+      defaultContexts: new Map([
+        [ContextAlpha, new ContextAlphaImpl(`immediate-parent-alpha`)],
+      ]),
+    };
+  }
+}

--- a/test/fixtures/context-app.js
+++ b/test/fixtures/context-app.js
@@ -78,7 +78,7 @@ export class ContextAlphaSlottedWidget extends Component {
   get config() {
     return {
       template: (state) =>
-        h(`div`, {class: {foo: true}}),
+        h(`slot`),
       defaultContexts: new Map([
         [ContextAlpha, new ContextAlphaImpl(`slotted-alpha`)],
       ]),
@@ -90,7 +90,7 @@ export class ContextAlphaAltSlottedWidget extends Component {
   get config() {
     return {
       template: (state) =>
-        h(`div`, {class: {foo: true}}),
+        h(`slot`),
       defaultContexts: new Map([
         [ContextAlpha, new ContextAlphaAltImpl()],
       ]),
@@ -161,6 +161,56 @@ export class ContextBravoParentWithNestedAlphaWidgets extends Component {
         ]),
       defaultContexts: new Map([
         [ContextBravo, new ContextBravoImpl(`parent-bravo`)],
+      ]),
+    };
+  }
+}
+
+export class ContextlessSlottedWrapper extends Component {
+  get config() {
+    return {
+      template: (state) =>
+        h(`slot`),
+    };
+  }
+}
+
+export class ContextParentWithContextlessSlottedWrapper extends Component {
+  get config() {
+    return {
+      template: (state) =>
+        h(`div`, {class: {foo: true}}, [
+          h(`p`, `asdf`),
+          h(`contextless-slotted-wrapper`, {class: {foo: true}}, [
+            h(`context-alpha-widget`),
+          ]),
+          h(`p`, `asdf`),
+        ]),
+      defaultContexts: new Map([
+        [ContextAlpha, new ContextAlphaImpl(`parent-alpha`)],
+      ]),
+    };
+  }
+}
+
+export class ContextlessComponentWrapper extends Component {
+  get config() {
+    return {
+      template: (state) =>
+        h(`context-alpha-widget`),
+    };
+  }
+}
+
+export class ContextParentWithContextlessComponentWrapper extends Component {
+  get config() {
+    return {
+      template: (state) =>
+        h(`div`, {class: {foo: true}}, [
+          h(`contextless-component-wrapper`),
+        ]),
+      defaultContexts: new Map([
+        [ContextAlpha, new ContextAlphaImpl(`parent-alpha`)],
       ]),
     };
   }

--- a/test/fixtures/context-app.js
+++ b/test/fixtures/context-app.js
@@ -1,5 +1,11 @@
 import {Component, h} from '../../lib';
-import {ContextAlpha, ContextAlphaImpl, ContextAlphaAltImpl} from './simple-contexts';
+import {
+  ContextAlpha,
+  ContextAlphaImpl,
+  ContextAlphaAltImpl,
+  ContextBravo,
+  ContextBravoImpl,
+} from './simple-contexts';
 
 export class ContextAlphaWidget extends Component {
   get config() {
@@ -20,6 +26,141 @@ export class ImmediateContextParent extends Component {
         h(`context-alpha-widget`, {class: {foo: true}}),
       defaultContexts: new Map([
         [ContextAlpha, new ContextAlphaImpl(`immediate-parent-alpha`)],
+      ]),
+    };
+  }
+}
+
+export class ImmediateContextParentWithWrapper extends Component {
+  get config() {
+    return {
+      template: (state) =>
+        h(`div`, {class: {foo: true}}, [
+          h(`p`, `asdf`),
+          h(`div`, {class: {foo: true}}, [
+            h(`div`, {class: {foo: true}}, [
+              h(`context-alpha-widget`),
+            ]),
+            h(`p`, `asdf`),
+          ]),
+          h(`p`, `asdf`),
+        ]),
+      defaultContexts: new Map([
+        [ContextAlpha, new ContextAlphaImpl(`immediate-parent-alpha-with-wrapper`)],
+      ]),
+    };
+  }
+}
+
+export class ShadowDomContextParent extends Component {
+  get config() {
+    return {
+      template: (state) =>
+        h(`div`, {class: {foo: true}}, [
+          h(`p`, `asdf`),
+          h(`div`, {class: {foo: true}}, [
+            h(`div`, {class: {foo: true}}, [
+              h(`context-alpha-widget`),
+            ]),
+            h(`p`, `asdf`),
+          ]),
+          h(`p`, `asdf`),
+        ]),
+      defaultContexts: new Map([
+        [ContextAlpha, new ContextAlphaImpl(`shadow-dom-parent-alpha`)],
+      ]),
+      useShadowDom: true,
+    };
+  }
+}
+
+export class ContextAlphaSlottedWidget extends Component {
+  get config() {
+    return {
+      template: (state) =>
+        h(`div`, {class: {foo: true}}),
+      defaultContexts: new Map([
+        [ContextAlpha, new ContextAlphaImpl(`slotted-alpha`)],
+      ]),
+    };
+  }
+}
+
+export class ContextAlphaAltSlottedWidget extends Component {
+  get config() {
+    return {
+      template: (state) =>
+        h(`div`, {class: {foo: true}}),
+      defaultContexts: new Map([
+        [ContextAlpha, new ContextAlphaAltImpl()],
+      ]),
+    };
+  }
+}
+
+export class NestedSlottedContextWidgets extends Component {
+  get config() {
+    return {
+      template: (state) =>
+        h(`div`, {class: {foo: true}}, [
+          h(`p`, `asdf`),
+          h(`context-alpha-slotted-widget`, {class: {foo: true}}, [
+            h(`span`, {class: {foo: true}}, [
+              h(`context-alpha-alt-slotted-widget`, {class: {foo: true}}, [
+                h(`context-alpha-widget`),
+              ]),
+            ]),
+            h(`p`, `asdf`),
+          ]),
+          h(`p`, `asdf`),
+        ]),
+    };
+  }
+}
+
+export class ContextGrandparent extends Component {
+  get config() {
+    return {
+      template: (state) =>
+        h(`immediate-context-parent`, {class: {foo: true}}),
+      defaultContexts: new Map([
+        [ContextAlpha, new ContextAlphaImpl(`grandparent-alpha`)],
+      ]),
+    };
+  }
+}
+
+export class ContextBravoWidget extends Component {
+  get config() {
+    return {
+      template: (state) =>
+        h(`div`, {class: {foo: true}}),
+      defaultContexts: new Map([
+        [ContextBravo, new ContextBravoImpl(`default-bravo`)],
+      ]),
+    };
+  }
+}
+
+export class ContextBravoParentWithNestedAlphaWidgets extends Component {
+  get config() {
+    return {
+      template: (state) =>
+        h(`div`, {class: {foo: true}}, [
+          h(`p`, `asdf`),
+          h(`context-alpha-slotted-widget`, {class: {foo: true}}, [
+            h(`span`, {class: {foo: true}}, [
+              h(`context-alpha-alt-slotted-widget`, {class: {foo: true}}, [
+                h(`context-alpha-widget`),
+                h(`context-bravo-widget`),
+              ]),
+            ]),
+            h(`p`, `asdf`),
+          ]),
+          h(`p`, `asdf`),
+        ]),
+      defaultContexts: new Map([
+        [ContextBravo, new ContextBravoImpl(`parent-bravo`)],
       ]),
     };
   }

--- a/test/fixtures/context-app.js
+++ b/test/fixtures/context-app.js
@@ -1,5 +1,5 @@
 import {Component, h} from '../../lib';
-import {ContextAlpha, ContextAlphaImpl, ContextAlphaAltImpl, ContextBravo, ContextBravoImpl} from './simple-contexts';
+import {ContextAlphaImpl, ContextAlphaAltImpl, ContextBravoImpl} from './simple-contexts';
 
 export class ContextAlphaWidget extends Component {
   get config() {

--- a/test/fixtures/context-app.js
+++ b/test/fixtures/context-app.js
@@ -10,7 +10,7 @@ import {
 export class ContextAlphaWidget extends Component {
   get config() {
     return {
-      template: (state) =>
+      template: () =>
         h(`div`, {class: {foo: true}}),
       defaultContexts: new Map([
         [ContextAlpha, new ContextAlphaImpl(`default-alpha`)],
@@ -22,7 +22,7 @@ export class ContextAlphaWidget extends Component {
 export class ImmediateContextParent extends Component {
   get config() {
     return {
-      template: (state) =>
+      template: () =>
         h(`context-alpha-widget`, {class: {foo: true}}),
       defaultContexts: new Map([
         [ContextAlpha, new ContextAlphaImpl(`immediate-parent-alpha`)],
@@ -34,7 +34,7 @@ export class ImmediateContextParent extends Component {
 export class ImmediateContextParentWithWrapper extends Component {
   get config() {
     return {
-      template: (state) =>
+      template: () =>
         h(`div`, {class: {foo: true}}, [
           h(`p`, `asdf`),
           h(`div`, {class: {foo: true}}, [
@@ -55,7 +55,7 @@ export class ImmediateContextParentWithWrapper extends Component {
 export class ShadowDomContextParent extends Component {
   get config() {
     return {
-      template: (state) =>
+      template: () =>
         h(`div`, {class: {foo: true}}, [
           h(`p`, `asdf`),
           h(`div`, {class: {foo: true}}, [
@@ -77,7 +77,7 @@ export class ShadowDomContextParent extends Component {
 export class ContextAlphaSlottedWidget extends Component {
   get config() {
     return {
-      template: (state) =>
+      template: () =>
         h(`slot`),
       defaultContexts: new Map([
         [ContextAlpha, new ContextAlphaImpl(`slotted-alpha`)],
@@ -89,7 +89,7 @@ export class ContextAlphaSlottedWidget extends Component {
 export class ContextAlphaAltSlottedWidget extends Component {
   get config() {
     return {
-      template: (state) =>
+      template: () =>
         h(`slot`),
       defaultContexts: new Map([
         [ContextAlpha, new ContextAlphaAltImpl()],
@@ -101,7 +101,7 @@ export class ContextAlphaAltSlottedWidget extends Component {
 export class NestedSlottedContextWidgets extends Component {
   get config() {
     return {
-      template: (state) =>
+      template: () =>
         h(`div`, {class: {foo: true}}, [
           h(`p`, `asdf`),
           h(`context-alpha-slotted-widget`, {class: {foo: true}}, [
@@ -121,7 +121,7 @@ export class NestedSlottedContextWidgets extends Component {
 export class ContextGrandparent extends Component {
   get config() {
     return {
-      template: (state) =>
+      template: () =>
         h(`immediate-context-parent`, {class: {foo: true}}),
       defaultContexts: new Map([
         [ContextAlpha, new ContextAlphaImpl(`grandparent-alpha`)],
@@ -133,7 +133,7 @@ export class ContextGrandparent extends Component {
 export class ContextBravoWidget extends Component {
   get config() {
     return {
-      template: (state) =>
+      template: () =>
         h(`div`, {class: {foo: true}}),
       defaultContexts: new Map([
         [ContextBravo, new ContextBravoImpl(`default-bravo`)],
@@ -145,7 +145,7 @@ export class ContextBravoWidget extends Component {
 export class ContextBravoParentWithNestedAlphaWidgets extends Component {
   get config() {
     return {
-      template: (state) =>
+      template: () =>
         h(`div`, {class: {foo: true}}, [
           h(`p`, `asdf`),
           h(`context-alpha-slotted-widget`, {class: {foo: true}}, [
@@ -169,7 +169,7 @@ export class ContextBravoParentWithNestedAlphaWidgets extends Component {
 export class ContextlessSlottedWrapper extends Component {
   get config() {
     return {
-      template: (state) =>
+      template: () =>
         h(`slot`),
     };
   }
@@ -178,7 +178,7 @@ export class ContextlessSlottedWrapper extends Component {
 export class ContextParentWithContextlessSlottedWrapper extends Component {
   get config() {
     return {
-      template: (state) =>
+      template: () =>
         h(`div`, {class: {foo: true}}, [
           h(`p`, `asdf`),
           h(`contextless-slotted-wrapper`, {class: {foo: true}}, [
@@ -196,7 +196,7 @@ export class ContextParentWithContextlessSlottedWrapper extends Component {
 export class ContextlessComponentWrapper extends Component {
   get config() {
     return {
-      template: (state) =>
+      template: () =>
         h(`context-alpha-widget`),
     };
   }
@@ -205,7 +205,7 @@ export class ContextlessComponentWrapper extends Component {
 export class ContextParentWithContextlessComponentWrapper extends Component {
   get config() {
     return {
-      template: (state) =>
+      template: () =>
         h(`div`, {class: {foo: true}}, [
           h(`contextless-component-wrapper`),
         ]),

--- a/test/fixtures/context-app.js
+++ b/test/fixtures/context-app.js
@@ -5,7 +5,7 @@ export class ContextAlphaWidget extends Component {
   get config() {
     return {
       template: () => h(`div`, {class: {foo: true}}),
-      defaultContexts: new Map([[ContextAlpha, new ContextAlphaImpl(`default-alpha`)]]),
+      defaultContexts: {alpha: new ContextAlphaImpl(`default-alpha`)},
     };
   }
 }
@@ -14,7 +14,7 @@ export class ImmediateContextParent extends Component {
   get config() {
     return {
       template: () => h(`context-alpha-widget`, {class: {foo: true}}),
-      defaultContexts: new Map([[ContextAlpha, new ContextAlphaImpl(`immediate-parent-alpha`)]]),
+      defaultContexts: {alpha: new ContextAlphaImpl(`immediate-parent-alpha`)},
     };
   }
 }
@@ -28,7 +28,7 @@ export class ImmediateContextParentWithWrapper extends Component {
           h(`div`, {class: {foo: true}}, [h(`div`, {class: {foo: true}}, [h(`context-alpha-widget`)]), h(`p`, `asdf`)]),
           h(`p`, `asdf`),
         ]),
-      defaultContexts: new Map([[ContextAlpha, new ContextAlphaImpl(`immediate-parent-alpha-with-wrapper`)]]),
+      defaultContexts: {alpha: new ContextAlphaImpl(`immediate-parent-alpha-with-wrapper`)},
     };
   }
 }
@@ -42,7 +42,7 @@ export class ShadowDomContextParent extends Component {
           h(`div`, {class: {foo: true}}, [h(`div`, {class: {foo: true}}, [h(`context-alpha-widget`)]), h(`p`, `asdf`)]),
           h(`p`, `asdf`),
         ]),
-      defaultContexts: new Map([[ContextAlpha, new ContextAlphaImpl(`shadow-dom-parent-alpha`)]]),
+      defaultContexts: {alpha: new ContextAlphaImpl(`shadow-dom-parent-alpha`)},
       useShadowDom: true,
     };
   }
@@ -52,7 +52,7 @@ export class ContextAlphaSlottedWidget extends Component {
   get config() {
     return {
       template: () => h(`slot`),
-      defaultContexts: new Map([[ContextAlpha, new ContextAlphaImpl(`slotted-alpha`)]]),
+      defaultContexts: {alpha: new ContextAlphaImpl(`slotted-alpha`)},
     };
   }
 }
@@ -61,7 +61,7 @@ export class ContextAlphaAltSlottedWidget extends Component {
   get config() {
     return {
       template: () => h(`slot`),
-      defaultContexts: new Map([[ContextAlpha, new ContextAlphaAltImpl()]]),
+      defaultContexts: {alpha: new ContextAlphaAltImpl()},
     };
   }
 }
@@ -88,7 +88,7 @@ export class ContextGrandparent extends Component {
   get config() {
     return {
       template: () => h(`immediate-context-parent`, {class: {foo: true}}),
-      defaultContexts: new Map([[ContextAlpha, new ContextAlphaImpl(`grandparent-alpha`)]]),
+      defaultContexts: {alpha: new ContextAlphaImpl(`grandparent-alpha`)},
     };
   }
 }
@@ -97,7 +97,7 @@ export class ContextBravoWidget extends Component {
   get config() {
     return {
       template: () => h(`div`, {class: {foo: true}}),
-      defaultContexts: new Map([[ContextBravo, new ContextBravoImpl(`default-bravo`)]]),
+      defaultContexts: {bravo: new ContextBravoImpl(`default-bravo`)},
     };
   }
 }
@@ -119,7 +119,7 @@ export class ContextBravoParentWithNestedAlphaWidgets extends Component {
           ]),
           h(`p`, `asdf`),
         ]),
-      defaultContexts: new Map([[ContextBravo, new ContextBravoImpl(`parent-bravo`)]]),
+      defaultContexts: {bravo: new ContextBravoImpl(`parent-bravo`)},
     };
   }
 }
@@ -141,7 +141,7 @@ export class ContextParentWithContextlessSlottedWrapper extends Component {
           h(`contextless-slotted-wrapper`, {class: {foo: true}}, [h(`context-alpha-widget`)]),
           h(`p`, `asdf`),
         ]),
-      defaultContexts: new Map([[ContextAlpha, new ContextAlphaImpl(`parent-alpha`)]]),
+      defaultContexts: {alpha: new ContextAlphaImpl(`parent-alpha`)},
     };
   }
 }
@@ -158,7 +158,7 @@ export class ContextParentWithContextlessComponentWrapper extends Component {
   get config() {
     return {
       template: () => h(`div`, {class: {foo: true}}, [h(`contextless-component-wrapper`)]),
-      defaultContexts: new Map([[ContextAlpha, new ContextAlphaImpl(`parent-alpha`)]]),
+      defaultContexts: {alpha: new ContextAlphaImpl(`parent-alpha`)},
     };
   }
 }

--- a/test/fixtures/context-app.js
+++ b/test/fixtures/context-app.js
@@ -1,5 +1,5 @@
 import {Component, h} from '../../lib';
-import {LightTheme, DarkTheme} from './simple-contexts';
+import {LightTheme, DarkTheme, LoadCounter} from './simple-contexts';
 
 export class DefaultLightThemedWidget extends Component {
   get config() {
@@ -22,6 +22,15 @@ export class ThemedWidget extends Component {
   }
 }
 
+export class MultiThemedWidget extends Component {
+  get config() {
+    return {
+      template: () => h(`div`, {class: {foo: true}}),
+      contexts: [`theme`, `invertedTheme`],
+    };
+  }
+}
+
 export class DarkApp extends Component {
   get config() {
     return {
@@ -29,9 +38,7 @@ export class DarkApp extends Component {
         h(`div`, {class: {foo: true}}, [
           h(`p`, `asdf`),
           h(`div`, {class: {foo: true}}, [
-            h(`div`, {class: {foo: true}}, [
-              h(`default-light-themed-widget`),
-            ]),
+            h(`div`, {class: {foo: true}}, [h(`default-light-themed-widget`)]),
             h(`p`, `asdf`),
           ]),
           h(`p`, `asdf`),
@@ -48,9 +55,7 @@ export class ShadowDomDarkApp extends Component {
         h(`div`, {class: {foo: true}}, [
           h(`p`, `asdf`),
           h(`div`, {class: {foo: true}}, [
-            h(`div`, {class: {foo: true}}, [
-              h(`default-light-themed-widget`),
-            ]),
+            h(`div`, {class: {foo: true}}, [h(`default-light-themed-widget`)]),
             h(`p`, `asdf`),
           ]),
           h(`p`, `asdf`),
@@ -67,15 +72,57 @@ export class SlottedDarkApp extends Component {
       template: () =>
         h(`div`, {class: {foo: true}}, [
           h(`p`, `asdf`),
-          h(`div`, {class: {foo: true}}, [
-            h(`div`, {class: {foo: true}}, [
-              h(`slot`),
-            ]),
-            h(`p`, `asdf`),
-          ]),
+          h(`div`, {class: {foo: true}}, [h(`div`, {class: {foo: true}}, [h(`slot`)]), h(`p`, `asdf`)]),
           h(`p`, `asdf`),
         ]),
       defaultContexts: {theme: new DarkTheme()},
+      useShadowDom: true,
+    };
+  }
+}
+
+export class SlottedLightApp extends Component {
+  get config() {
+    return {
+      template: () =>
+        h(`div`, {class: {foo: true}}, [
+          h(`p`, `asdf`),
+          h(`div`, {class: {foo: true}}, [h(`div`, {class: {foo: true}}, [h(`slot`)]), h(`p`, `asdf`)]),
+          h(`p`, `asdf`),
+        ]),
+      contexts: [`theme`],
+      defaultContexts: {theme: new LightTheme()},
+      useShadowDom: true,
+    };
+  }
+}
+
+export class SlottedInvertedLightApp extends Component {
+  get config() {
+    return {
+      template: () =>
+        h(`div`, {class: {foo: true}}, [
+          h(`p`, `asdf`),
+          h(`div`, {class: {foo: true}}, [h(`div`, {class: {foo: true}}, [h(`slot`)]), h(`p`, `asdf`)]),
+          h(`p`, `asdf`),
+        ]),
+      defaultContexts: {invertedTheme: new LightTheme()},
+      useShadowDom: true,
+    };
+  }
+}
+
+export class SlottedLoadCounterWidget extends Component {
+  get config() {
+    return {
+      template: () =>
+        h(`div`, {class: {foo: true}}, [
+          h(`p`, `asdf`),
+          h(`div`, {class: {foo: true}}, [h(`div`, {class: {foo: true}}, [h(`slot`)]), h(`p`, `asdf`)]),
+          h(`p`, `asdf`),
+        ]),
+      contexts: [`loadCounter`],
+      defaultContexts: {loadCounter: new LoadCounter()},
       useShadowDom: true,
     };
   }

--- a/test/fixtures/context-app.js
+++ b/test/fixtures/context-app.js
@@ -4,7 +4,7 @@ import {LightTheme, DarkTheme, LoadCounter} from './simple-contexts';
 export class DefaultLightThemedWidget extends Component {
   get config() {
     return {
-      template: () => h(`div`, {class: {foo: true}}),
+      template: () => h(`div`, {class: {[this.getContext(`theme`).getName()]: true}}),
       contexts: [`theme`],
       defaultContexts: {
         theme: new LightTheme(),
@@ -16,7 +16,7 @@ export class DefaultLightThemedWidget extends Component {
 export class ThemedWidget extends Component {
   get config() {
     return {
-      template: () => h(`div`, {class: {foo: true}}),
+      template: () => h(`div`, {class: {[this.getContext(`theme`).getName()]: true}}),
       contexts: [`theme`],
     };
   }
@@ -25,7 +25,10 @@ export class ThemedWidget extends Component {
 export class MultiThemedWidget extends Component {
   get config() {
     return {
-      template: () => h(`div`, {class: {foo: true}}),
+      template: () =>
+        h(`div`, {
+          class: {[this.getContext(`theme`).getName()]: true, [this.getContext(`invertedTheme`).getName()]: true},
+        }),
       contexts: [`theme`, `invertedTheme`],
     };
   }
@@ -85,7 +88,7 @@ export class SlottedLightApp extends Component {
   get config() {
     return {
       template: () =>
-        h(`div`, {class: {foo: true}}, [
+        h(`div`, {class: {[this.getContext(`theme`).getName()]: true}}, [
           h(`p`, `asdf`),
           h(`div`, {class: {foo: true}}, [h(`div`, {class: {foo: true}}, [h(`slot`)]), h(`p`, `asdf`)]),
           h(`p`, `asdf`),

--- a/test/fixtures/context-app.js
+++ b/test/fixtures/context-app.js
@@ -1,164 +1,82 @@
 import {Component, h} from '../../lib';
-import {ContextAlphaImpl, ContextAlphaAltImpl, ContextBravoImpl} from './simple-contexts';
+import {LightTheme, DarkTheme} from './simple-contexts';
 
-export class ContextAlphaWidget extends Component {
+export class DefaultLightThemedWidget extends Component {
   get config() {
     return {
       template: () => h(`div`, {class: {foo: true}}),
-      attachedContexts: [`alpha`],
+      contexts: [`theme`],
+      defaultContexts: {
+        theme: new LightTheme(),
+      },
     };
   }
 }
 
-export class ImmediateContextParent extends Component {
+export class ThemedWidget extends Component {
   get config() {
     return {
-      template: () => h(`context-alpha-widget`, {class: {foo: true}}),
-      defaultContexts: {alpha: new ContextAlphaImpl(`immediate-parent-alpha`)},
+      template: () => h(`div`, {class: {foo: true}}),
+      contexts: [`theme`],
     };
   }
 }
 
-export class ImmediateContextParentWithWrapper extends Component {
-  get config() {
-    return {
-      template: () =>
-        h(`div`, {class: {foo: true}}, [
-          h(`p`, `asdf`),
-          h(`div`, {class: {foo: true}}, [h(`div`, {class: {foo: true}}, [h(`context-alpha-widget`)]), h(`p`, `asdf`)]),
-          h(`p`, `asdf`),
-        ]),
-      defaultContexts: {alpha: new ContextAlphaImpl(`immediate-parent-alpha-with-wrapper`)},
-    };
-  }
-}
-
-export class ShadowDomContextParent extends Component {
+export class DarkApp extends Component {
   get config() {
     return {
       template: () =>
         h(`div`, {class: {foo: true}}, [
           h(`p`, `asdf`),
-          h(`div`, {class: {foo: true}}, [h(`div`, {class: {foo: true}}, [h(`context-alpha-widget`)]), h(`p`, `asdf`)]),
+          h(`div`, {class: {foo: true}}, [
+            h(`div`, {class: {foo: true}}, [
+              h(`default-light-themed-widget`),
+            ]),
+            h(`p`, `asdf`),
+          ]),
           h(`p`, `asdf`),
         ]),
-      defaultContexts: {alpha: new ContextAlphaImpl(`shadow-dom-parent-alpha`)},
+      defaultContexts: {theme: new DarkTheme()},
+    };
+  }
+}
+
+export class ShadowDomDarkApp extends Component {
+  get config() {
+    return {
+      template: () =>
+        h(`div`, {class: {foo: true}}, [
+          h(`p`, `asdf`),
+          h(`div`, {class: {foo: true}}, [
+            h(`div`, {class: {foo: true}}, [
+              h(`default-light-themed-widget`),
+            ]),
+            h(`p`, `asdf`),
+          ]),
+          h(`p`, `asdf`),
+        ]),
+      defaultContexts: {theme: new DarkTheme()},
       useShadowDom: true,
     };
   }
 }
 
-export class ContextAlphaSlottedWidget extends Component {
-  get config() {
-    return {
-      template: () => h(`slot`),
-      defaultContexts: {alpha: new ContextAlphaImpl(`slotted-alpha`)},
-    };
-  }
-}
-
-export class ContextAlphaAltSlottedWidget extends Component {
-  get config() {
-    return {
-      template: () => h(`slot`),
-      defaultContexts: {alpha: new ContextAlphaAltImpl()},
-    };
-  }
-}
-
-export class NestedSlottedContextWidgets extends Component {
+export class SlottedDarkApp extends Component {
   get config() {
     return {
       template: () =>
         h(`div`, {class: {foo: true}}, [
           h(`p`, `asdf`),
-          h(`context-alpha-slotted-widget`, {class: {foo: true}}, [
-            h(`span`, {class: {foo: true}}, [
-              h(`context-alpha-alt-slotted-widget`, {class: {foo: true}}, [h(`context-alpha-widget`)]),
+          h(`div`, {class: {foo: true}}, [
+            h(`div`, {class: {foo: true}}, [
+              h(`slot`),
             ]),
             h(`p`, `asdf`),
           ]),
           h(`p`, `asdf`),
         ]),
-    };
-  }
-}
-
-export class ContextGrandparent extends Component {
-  get config() {
-    return {
-      template: () => h(`immediate-context-parent`, {class: {foo: true}}),
-      defaultContexts: {alpha: new ContextAlphaImpl(`grandparent-alpha`)},
-    };
-  }
-}
-
-export class ContextBravoWidget extends Component {
-  get config() {
-    return {
-      template: () => h(`div`, {class: {foo: true}}),
-      attachedContexts: [`bravo`],
-    };
-  }
-}
-
-export class ContextBravoParentWithNestedAlphaWidgets extends Component {
-  get config() {
-    return {
-      template: () =>
-        h(`div`, {class: {foo: true}}, [
-          h(`p`, `asdf`),
-          h(`context-alpha-slotted-widget`, {class: {foo: true}}, [
-            h(`span`, {class: {foo: true}}, [
-              h(`context-alpha-alt-slotted-widget`, {class: {foo: true}}, [
-                h(`context-alpha-widget`),
-                h(`context-bravo-widget`),
-              ]),
-            ]),
-            h(`p`, `asdf`),
-          ]),
-          h(`p`, `asdf`),
-        ]),
-      defaultContexts: {bravo: new ContextBravoImpl(`parent-bravo`)},
-    };
-  }
-}
-
-export class ContextlessSlottedWrapper extends Component {
-  get config() {
-    return {
-      template: () => h(`slot`),
-    };
-  }
-}
-
-export class ContextParentWithContextlessSlottedWrapper extends Component {
-  get config() {
-    return {
-      template: () =>
-        h(`div`, {class: {foo: true}}, [
-          h(`p`, `asdf`),
-          h(`contextless-slotted-wrapper`, {class: {foo: true}}, [h(`context-alpha-widget`)]),
-          h(`p`, `asdf`),
-        ]),
-      defaultContexts: {alpha: new ContextAlphaImpl(`parent-alpha`)},
-    };
-  }
-}
-
-export class ContextlessComponentWrapper extends Component {
-  get config() {
-    return {
-      template: () => h(`context-alpha-widget`),
-    };
-  }
-}
-
-export class ContextParentWithContextlessComponentWrapper extends Component {
-  get config() {
-    return {
-      template: () => h(`div`, {class: {foo: true}}, [h(`contextless-component-wrapper`)]),
-      defaultContexts: {alpha: new ContextAlphaImpl(`parent-alpha`)},
+      defaultContexts: {theme: new DarkTheme()},
+      useShadowDom: true,
     };
   }
 }

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -12,9 +12,13 @@ import {SimpleApp} from './simple-app';
 import {
   DefaultLightThemedWidget,
   ThemedWidget,
+  MultiThemedWidget,
   DarkApp,
   ShadowDomDarkApp,
   SlottedDarkApp,
+  SlottedLightApp,
+  SlottedInvertedLightApp,
+  SlottedLoadCounterWidget,
 } from './context-app';
 
 customElements.define(`attrs-reflection-app`, AttrsReflectionApp);
@@ -36,6 +40,10 @@ customElements.define(`simple-app`, SimpleApp);
 
 customElements.define(`default-light-themed-widget`, DefaultLightThemedWidget);
 customElements.define(`themed-widget`, ThemedWidget);
+customElements.define(`multi-themed-widget`, MultiThemedWidget);
 customElements.define(`dark-app`, DarkApp);
 customElements.define(`shadow-dom-dark-app`, ShadowDomDarkApp);
 customElements.define(`slotted-dark-app`, SlottedDarkApp);
+customElements.define(`slotted-light-app`, SlottedLightApp);
+customElements.define(`slotted-inverted-light-app`, SlottedInvertedLightApp);
+customElements.define(`slotted-load-counter-widget`, SlottedLoadCounterWidget);

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -10,8 +10,16 @@ import {BadBooleanRequiredAttrsSchemaApp, RequiredAttrsSchemaApp} from './requir
 import {ShadowDomApp} from './shadow-dom-app';
 import {SimpleApp} from './simple-app';
 import {
-	ContextAlphaWidget,
-	ImmediateContextParent,
+  ContextAlphaWidget,
+  ImmediateContextParent,
+  ImmediateContextParentWithWrapper,
+  ShadowDomContextParent,
+  ContextAlphaSlottedWidget,
+  ContextAlphaAltSlottedWidget,
+  NestedSlottedContextWidgets,
+  ContextGrandparent,
+  ContextBravoWidget,
+  ContextBravoParentWithNestedAlphaWidgets,
 } from './context-app';
 
 customElements.define(`attrs-reflection-app`, AttrsReflectionApp);
@@ -33,3 +41,11 @@ customElements.define(`simple-app`, SimpleApp);
 
 customElements.define(`context-alpha-widget`, ContextAlphaWidget);
 customElements.define(`immediate-context-parent`, ImmediateContextParent);
+customElements.define(`immediate-context-parent-with-wrapper`, ImmediateContextParentWithWrapper);
+customElements.define(`shadow-dom-context-parent`, ShadowDomContextParent);
+customElements.define(`context-alpha-slotted-widget`, ContextAlphaSlottedWidget);
+customElements.define(`context-alpha-alt-slotted-widget`, ContextAlphaAltSlottedWidget);
+customElements.define(`nested-slotted-context-widgets`, NestedSlottedContextWidgets);
+customElements.define(`context-grandparent`, ContextGrandparent);
+customElements.define(`context-bravo-widget`, ContextBravoWidget);
+customElements.define(`context-bravo-parent-with-nested-alpha-widgets`, ContextBravoParentWithNestedAlphaWidgets);

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -10,20 +10,11 @@ import {BadBooleanRequiredAttrsSchemaApp, RequiredAttrsSchemaApp} from './requir
 import {ShadowDomApp} from './shadow-dom-app';
 import {SimpleApp} from './simple-app';
 import {
-  ContextAlphaWidget,
-  ImmediateContextParent,
-  ImmediateContextParentWithWrapper,
-  ShadowDomContextParent,
-  ContextAlphaSlottedWidget,
-  ContextAlphaAltSlottedWidget,
-  NestedSlottedContextWidgets,
-  ContextGrandparent,
-  ContextBravoWidget,
-  ContextBravoParentWithNestedAlphaWidgets,
-  ContextlessSlottedWrapper,
-  ContextParentWithContextlessSlottedWrapper,
-  ContextlessComponentWrapper,
-  ContextParentWithContextlessComponentWrapper,
+  DefaultLightThemedWidget,
+  ThemedWidget,
+  DarkApp,
+  ShadowDomDarkApp,
+  SlottedDarkApp,
 } from './context-app';
 
 customElements.define(`attrs-reflection-app`, AttrsReflectionApp);
@@ -43,20 +34,8 @@ customElements.define(`required-attrs-schema-app`, RequiredAttrsSchemaApp);
 customElements.define(`shadow-dom-app`, ShadowDomApp);
 customElements.define(`simple-app`, SimpleApp);
 
-customElements.define(`context-alpha-widget`, ContextAlphaWidget);
-customElements.define(`immediate-context-parent`, ImmediateContextParent);
-customElements.define(`immediate-context-parent-with-wrapper`, ImmediateContextParentWithWrapper);
-customElements.define(`shadow-dom-context-parent`, ShadowDomContextParent);
-customElements.define(`context-alpha-slotted-widget`, ContextAlphaSlottedWidget);
-customElements.define(`context-alpha-alt-slotted-widget`, ContextAlphaAltSlottedWidget);
-customElements.define(`nested-slotted-context-widgets`, NestedSlottedContextWidgets);
-customElements.define(`context-grandparent`, ContextGrandparent);
-customElements.define(`context-bravo-widget`, ContextBravoWidget);
-customElements.define(`context-bravo-parent-with-nested-alpha-widgets`, ContextBravoParentWithNestedAlphaWidgets);
-customElements.define(`contextless-slotted-wrapper`, ContextlessSlottedWrapper);
-customElements.define(`context-parent-with-contextless-slotted-wrapper`, ContextParentWithContextlessSlottedWrapper);
-customElements.define(`contextless-component-wrapper`, ContextlessComponentWrapper);
-customElements.define(
-  `context-parent-with-contextless-component-wrapper`,
-  ContextParentWithContextlessComponentWrapper,
-);
+customElements.define(`default-light-themed-widget`, DefaultLightThemedWidget);
+customElements.define(`themed-widget`, ThemedWidget);
+customElements.define(`dark-app`, DarkApp);
+customElements.define(`shadow-dom-dark-app`, ShadowDomDarkApp);
+customElements.define(`slotted-dark-app`, SlottedDarkApp);

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -56,4 +56,7 @@ customElements.define(`context-bravo-parent-with-nested-alpha-widgets`, ContextB
 customElements.define(`contextless-slotted-wrapper`, ContextlessSlottedWrapper);
 customElements.define(`context-parent-with-contextless-slotted-wrapper`, ContextParentWithContextlessSlottedWrapper);
 customElements.define(`contextless-component-wrapper`, ContextlessComponentWrapper);
-customElements.define(`context-parent-with-contextless-component-wrapper`, ContextParentWithContextlessComponentWrapper);
+customElements.define(
+  `context-parent-with-contextless-component-wrapper`,
+  ContextParentWithContextlessComponentWrapper,
+);

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -20,6 +20,10 @@ import {
   ContextGrandparent,
   ContextBravoWidget,
   ContextBravoParentWithNestedAlphaWidgets,
+  ContextlessSlottedWrapper,
+  ContextParentWithContextlessSlottedWrapper,
+  ContextlessComponentWrapper,
+  ContextParentWithContextlessComponentWrapper,
 } from './context-app';
 
 customElements.define(`attrs-reflection-app`, AttrsReflectionApp);
@@ -49,3 +53,7 @@ customElements.define(`nested-slotted-context-widgets`, NestedSlottedContextWidg
 customElements.define(`context-grandparent`, ContextGrandparent);
 customElements.define(`context-bravo-widget`, ContextBravoWidget);
 customElements.define(`context-bravo-parent-with-nested-alpha-widgets`, ContextBravoParentWithNestedAlphaWidgets);
+customElements.define(`contextless-slotted-wrapper`, ContextlessSlottedWrapper);
+customElements.define(`context-parent-with-contextless-slotted-wrapper`, ContextParentWithContextlessSlottedWrapper);
+customElements.define(`contextless-component-wrapper`, ContextlessComponentWrapper);
+customElements.define(`context-parent-with-contextless-component-wrapper`, ContextParentWithContextlessComponentWrapper);

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -9,6 +9,10 @@ import {NestedPartialStateParent, NestedPartialStateChild} from './nested-partia
 import {BadBooleanRequiredAttrsSchemaApp, RequiredAttrsSchemaApp} from './required-attrs-schema-apps';
 import {ShadowDomApp} from './shadow-dom-app';
 import {SimpleApp} from './simple-app';
+import {
+	ContextAlphaWidget,
+	ImmediateContextParent,
+} from './context-app';
 
 customElements.define(`attrs-reflection-app`, AttrsReflectionApp);
 customElements.define(`bad-attrs-schema-app`, BadAttrsSchemaApp);
@@ -26,3 +30,6 @@ customElements.define(`nested-partial-state-child`, NestedPartialStateChild);
 customElements.define(`required-attrs-schema-app`, RequiredAttrsSchemaApp);
 customElements.define(`shadow-dom-app`, ShadowDomApp);
 customElements.define(`simple-app`, SimpleApp);
+
+customElements.define(`context-alpha-widget`, ContextAlphaWidget);
+customElements.define(`immediate-context-parent`, ImmediateContextParent);

--- a/test/fixtures/simple-contexts.d.ts
+++ b/test/fixtures/simple-contexts.d.ts
@@ -1,0 +1,19 @@
+import {Component, PanelLifecycleContext} from '../../lib';
+
+export interface Theme {
+  getName(): string;
+}
+
+export class LightTheme implements Theme {
+  getName(): 'white';
+}
+
+export class DarkTheme implements Theme {
+  getName(): 'black';
+}
+
+export class LoadCounter implements PanelLifecycleContext {
+  bindToComponent(component: Component<any>): void;
+  unbindFromComponent(component: Component<any>): void;
+  getCount(): number;
+}

--- a/test/fixtures/simple-contexts.js
+++ b/test/fixtures/simple-contexts.js
@@ -15,3 +15,16 @@ export class ContextAlphaAltImpl extends ContextAlpha {
     return "alt-alpha";
   }
 }
+
+export class ContextBravo {
+  getBravo() {}
+}
+export class ContextBravoImpl extends ContextBravo {
+  constructor(testName) {
+    super();
+    this.testName = testName;
+  }
+  getTestName() {
+    return this.testName;
+  }
+}

--- a/test/fixtures/simple-contexts.js
+++ b/test/fixtures/simple-contexts.js
@@ -1,0 +1,17 @@
+export class ContextAlpha {
+  getTestName() {}
+}
+export class ContextAlphaImpl extends ContextAlpha {
+  constructor(testName) {
+    super();
+    this.testName = testName;
+  }
+  getTestName() {
+    return this.testName;
+  }
+}
+export class ContextAlphaAltImpl extends ContextAlpha {
+  getTestName() {
+    return "alt-alpha";
+  }
+}

--- a/test/fixtures/simple-contexts.js
+++ b/test/fixtures/simple-contexts.js
@@ -12,7 +12,7 @@ export class ContextAlphaImpl extends ContextAlpha {
 }
 export class ContextAlphaAltImpl extends ContextAlpha {
   getTestName() {
-    return "alt-alpha";
+    return `alt-alpha`;
   }
 }
 

--- a/test/fixtures/simple-contexts.js
+++ b/test/fixtures/simple-contexts.js
@@ -14,11 +14,11 @@ export class LoadCounter {
   constructor() {
     this.count = 0;
   }
-  bindToComponent(component) {
+  bindToComponent() {
     this.count += 1;
   }
-  unbindFromComponent(component) {
-    this.count += 1;
+  unbindFromComponent() {
+    this.count -= 1;
   }
   getCount() {
     return this.count;

--- a/test/fixtures/simple-contexts.js
+++ b/test/fixtures/simple-contexts.js
@@ -1,30 +1,26 @@
-export class ContextAlpha {
-  getTestName() {}
-}
-export class ContextAlphaImpl extends ContextAlpha {
-  constructor(testName) {
-    super();
-    this.testName = testName;
-  }
-  getTestName() {
-    return this.testName;
-  }
-}
-export class ContextAlphaAltImpl extends ContextAlpha {
-  getTestName() {
-    return `alt-alpha`;
+export class LightTheme {
+  getName() {
+    return `light`;
   }
 }
 
-export class ContextBravo {
-  getBravo() {}
-}
-export class ContextBravoImpl extends ContextBravo {
-  constructor(testName) {
-    super();
-    this.testName = testName;
+export class DarkTheme {
+  getName() {
+    return `dark`;
   }
-  getTestName() {
-    return this.testName;
+}
+
+export class LoadCounter {
+  constructor() {
+    this.count = 0;
+  }
+  bindToComponent(component) {
+    this.count += 1;
+  }
+  unbindFromComponent(component) {
+    this.count += 1;
+  }
+  getCount() {
+    return this.count;
   }
 }


### PR DESCRIPTION
Proposal: https://www.notion.so/mpspeed/Draft-proposal-for-sharing-data-behaviors-and-visual-layouts-with-panel-contexts-4080b6911a4e43d98de7131600d7d21f

This is the ~draft~ implementation of my proposed "Contexts" feature that allows `panel` components to inject arbitrary class dependencies into all descendants at runtime.

I changed my implementation strategy from my initial plans (where contexts are assigned downwards into descendants) to an approach where contexts are pulled from DOM parent nodes by traversing upwards through ancestors.

This is arguably a fairly naive strategy that I had hoped to avoid, suggestions for alternative strategies are welcome.

Edit: the API spec has been updated twice from the draft:
- https://www.notion.so/mpspeed/API-update-1-quick-explainer-da4a6b7ad7a44fdfab2e32d7c3d16136
- https://www.notion.so/mpspeed/API-update-2-quick-explainer-df806e5ceed8428eb0574bcd5d54ecd8