### PR TITLE
types for hook-helpers

### DIFF
--- a/lib/component-utils/hook-helpers.d.ts
+++ b/lib/component-utils/hook-helpers.d.ts
@@ -1,0 +1,12 @@
+import {VNode} from 'snabbdom/vnode';
+
+/**
+ * A simple remove hook generator for snabbdom so we remove an element after it's finished its closing animation.
+ * The attr value is immediately set and after waitMs, it's removed from dom.
+ * @example hook={remove: delayedAttrRemove(`open`, `false`)}
+ */
+export function delayedAttrRemove(
+  attr: string,
+  value: string | number | boolean,
+  waitMs?: number,
+): (vnode: VNode, removeCallback: () => void) => void;

--- a/test/fixtures/delayed-attr-remove-app.js
+++ b/test/fixtures/delayed-attr-remove-app.js
@@ -1,5 +1,7 @@
 /* eslint-disable multiline-ternary */
+// @ts-check
 import {Component, h} from '../../lib';
+import {delayedAttrRemove} from '../../lib/component-utils/hook-helpers';
 
 export class DelayedAttrRemoveApp extends Component {
   static get attrsSchema() {
@@ -10,7 +12,7 @@ export class DelayedAttrRemoveApp extends Component {
 
   get config() {
     return {
-      template: ({$hooks, $attr}) =>
+      template: ({$attr}) =>
         h(
           `div`,
           [
@@ -19,7 +21,7 @@ export class DelayedAttrRemoveApp extends Component {
                   `my-modal`,
                   {
                     attrs: {open: true},
-                    hook: {remove: $hooks.delayedAttrRemove(`open`, `false`, 50)},
+                    hook: {remove: delayedAttrRemove(`open`, `false`, 50)},
                   },
                   `modal body!`,
                 )


### PR DESCRIPTION
context:

in jsx we want to `import {delatedAttrRemove} from 'panel/component-utils/hook-helpers';` directly as a function so we get the typed version.

