### PR TITLE
lifecycle helpers and tests

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -149,6 +149,31 @@ class Component extends WebComponent {
   }
 
   /**
+   * Enqueue a function to be run at the end of the components connectedCallback. It can optionally return
+   * a function to run during the component's disconnectedCallback
+   */
+  onConnected(fn) {
+    if (this.initialized) {
+      this._maybeEnqueueResult(fn.call(this));
+    }
+    this._connectedQueue.push(fn);
+  }
+
+  _maybeEnqueueResult(result) {
+    if (result && typeof result === `function`) {
+      result.removeAfterExec = true;
+      this._disconnectedQueue.push(result);
+    }
+  }
+
+  /**
+   * Enqueue a function to be run at the end of the components disconnectedCallback.
+   */
+  onDisconnected(fn) {
+    this._disconnectedQueue.push(fn);
+  }
+
+  /**
    * Sets a value in the component's configuration map after element
    * initialization.
    * @param {string} key - key of config item to set
@@ -321,33 +346,14 @@ class Component extends WebComponent {
       updateMode: this.getConfig(`updateSync`) ? `sync` : `async`,
     });
     this.el.appendChild(this.domPatcher.el);
+
+    for (let i = 0; i < this._connectedQueue.length; i++) {
+      const connectedCallbackFn = this._connectedQueue[i];
+      this._maybeEnqueueResult(connectedCallbackFn.call(this));
+    }
+
     this.initialized = true;
     this.initializing = false;
-
-    let connectedCallbackFn = this._connectedQueue.shift();
-    while (connectedCallbackFn) {
-      const result = connectedCallbackFn.call(this);
-      if (result && typeof result === `function`) {
-        this._disconnectedQueue.push(result);
-      }
-
-      connectedCallbackFn = this._connectedQueue.shift();
-    }
-  }
-
-  /**
-   * Enqueue a function to be run at the end of the components connectedCallback. It can optionally return
-   * a function to run during the components disconnectedCallback
-   */
-  onConnected(fn) {
-    if (this.initialized) {
-      const result = fn.call(this);
-      if (result && typeof result === `function`) {
-        this._disconnectedQueue.push(result);
-      }
-    } else {
-      this._connectedQueue.push(fn);
-    }
   }
 
   disconnectedCallback() {
@@ -355,11 +361,12 @@ class Component extends WebComponent {
       return;
     }
 
-    let disconnectedCallbackFn = this._disconnectedQueue.shift();
-    while (disconnectedCallbackFn) {
+    for (let i = 0; i < this._disconnectedQueue.length; i++) {
+      const disconnectedCallbackFn = this._disconnectedQueue[i];
       disconnectedCallbackFn.call(this);
-      disconnectedCallbackFn = this._disconnectedQueue.shift();
     }
+
+    this._disconnectedQueue = this._disconnectedQueue.filter((fn) => !fn.removeAfterExec);
 
     if (this.router) {
       this.router.unregisterListeners();
@@ -393,17 +400,6 @@ class Component extends WebComponent {
         this.app = null;
       }
     });
-  }
-
-  /**
-   * Enqueue a function to be run at the end of the components disconnectedCallback.
-   */
-  onDisconnected(fn) {
-    if (!this._disconnectedQueue) {
-      console.warn(`Unexpected call, onDisconnected queue has already been drained`);
-    } else {
-      this._disconnectedQueue.push(fn);
-    }
   }
 
   /**

--- a/lib/component.js
+++ b/lib/component.js
@@ -324,13 +324,15 @@ class Component extends WebComponent {
     this.initialized = true;
     this.initializing = false;
 
-    this._connectedQueue.forEach((fn) => {
-      const result = fn.call(this);
+    let connectedCallbackFn = this._connectedQueue.shift();
+    while (connectedCallbackFn) {
+      const result = connectedCallbackFn.call(this);
       if (result && typeof result === `function`) {
         this._disconnectedQueue.push(result);
       }
-    });
-    this._connectedQueue = null;
+
+      connectedCallbackFn = this._connectedQueue.shift();
+    }
   }
 
   /**
@@ -353,8 +355,11 @@ class Component extends WebComponent {
       return;
     }
 
-    this._disconnectedQueue.forEach((fn) => fn.call(this));
-    this._disconnectedQueue = null;
+    let disconnectedCallbackFn = this._disconnectedQueue.shift();
+    while (disconnectedCallbackFn) {
+      disconnectedCallbackFn.call(this);
+      disconnectedCallbackFn = this._disconnectedQueue.shift();
+    }
 
     if (this.router) {
       this.router.unregisterListeners();

--- a/lib/component.js
+++ b/lib/component.js
@@ -155,7 +155,8 @@ class Component extends WebComponent {
    *
    * It can optionally return a function to be enqueued to be run just before the component is
    * removed from the DOM. This occurs during the disconnectedCallback lifecycle.
-   * @param callback Function to be run after the component has been added to the DOM
+   * @param {function} fn - callback to be run after the component has been added to the DOM. If this
+   * callback returns another function, the returned function will be run when the component disconnects from the DOM.
    * @example
    * myApp.onConnected(() => {
    *   const handleResize = () => calculateSize();
@@ -181,7 +182,7 @@ class Component extends WebComponent {
    * Helper function which will queue a function to be run just before the component is
    * removed from the DOM. This occurs during the disconnectedCallback lifecycle.
    *
-   * @param callback Function to be run just before the component is removed from the DOM
+   * @param {function} fn - callback to be run just before the component is removed from the DOM
    * @example
    * connectedCallback() {
    *   const shiftKeyListener = () => {

--- a/lib/component.js
+++ b/lib/component.js
@@ -156,6 +156,12 @@ class Component extends WebComponent {
    * It can optionally return a function to be enqueued to be run just before the component is
    * removed from the DOM. This occurs during the disconnectedCallback lifecycle.
    * @param callback Function to be run after the component has been added to the DOM
+   * @example
+   * myApp.onConnected(() => {
+   *   const handleResize = () => calculateSize();
+   *   document.body.addEventListener(`resize`, handleResize);
+   *   return () => document.body.removeEventListener(`resize`, handleResize);
+   * });
    */
   onConnected(fn) {
     if (this.initialized) {
@@ -176,6 +182,21 @@ class Component extends WebComponent {
    * removed from the DOM. This occurs during the disconnectedCallback lifecycle.
    *
    * @param callback Function to be run just before the component is removed from the DOM
+   * @example
+   * connectedCallback() {
+   *   const shiftKeyListener = () => {
+   *     if (ev.keyCode === SHIFT_KEY_CODE) {
+   *       const doingRangeSelect = ev.type === `keydown` && this.isMouseOver && this.lastSelectedRowIdx !== null;
+   *       if (this.state.doingRangeSelect !== doingRangeSelect) {
+   *         this.update({doingRangeSelect});
+   *       }
+   *     }
+   *   }
+   *   document.body.addEventListener(`keydown`, shiftKeyListener);
+   *   this.onDisconnected(() => {
+   *     document.body.removeEventListener(`keydown`, shiftKeyListener);
+   *   });
+   * }
    */
   onDisconnected(fn) {
     this._disconnectedQueue.push(fn);

--- a/lib/component.js
+++ b/lib/component.js
@@ -214,6 +214,9 @@ class Component extends WebComponent {
 
     this.panelID = cuid();
 
+    this._connectedQueue = [];
+    this._disconnectedQueue = [];
+
     this._attrs = {};
     this._syncAttrs(); // constructor sync ensures default properties are present on this._attrs
 
@@ -320,12 +323,38 @@ class Component extends WebComponent {
     this.el.appendChild(this.domPatcher.el);
     this.initialized = true;
     this.initializing = false;
+
+    this._connectedQueue.forEach((fn) => {
+      const result = fn.call(this);
+      if (result && typeof result === `function`) {
+        this._disconnectedQueue.push(result);
+      }
+    });
+    this._connectedQueue = null;
+  }
+
+  /**
+   * Enqueue a function to be run at the end of the components connectedCallback. It can optionally return
+   * a function to run during the components disconnectedCallback
+   */
+  onConnected(fn) {
+    if (this.initialized) {
+      const result = fn.call(this);
+      if (result && typeof result === `function`) {
+        this._disconnectedQueue.push(result);
+      }
+    } else {
+      this._connectedQueue.push(fn);
+    }
   }
 
   disconnectedCallback() {
     if (!this.initialized) {
       return;
     }
+
+    this._disconnectedQueue.forEach((fn) => fn.call(this));
+    this._disconnectedQueue = null;
 
     if (this.router) {
       this.router.unregisterListeners();
@@ -359,6 +388,17 @@ class Component extends WebComponent {
         this.app = null;
       }
     });
+  }
+
+  /**
+   * Enqueue a function to be run at the end of the components disconnectedCallback.
+   */
+  onDisconnected(fn) {
+    if (!this._disconnectedQueue) {
+      console.warn(`Unexpected call, onDisconnected queue has already been drained`);
+    } else {
+      this._disconnectedQueue.push(fn);
+    }
   }
 
   /**

--- a/lib/component.js
+++ b/lib/component.js
@@ -149,8 +149,13 @@ class Component extends WebComponent {
   }
 
   /**
-   * Enqueue a function to be run at the end of the components connectedCallback. It can optionally return
-   * a function to run during the component's disconnectedCallback
+   * Helper function which will queue a function to be run once the component has been
+   * initialized and added to the DOM. If the component has already had its connectedCallback
+   * run, the function will run immediately.
+   *
+   * It can optionally return a function to be enqueued to be run just before the component is
+   * removed from the DOM. This occurs during the disconnectedCallback lifecycle.
+   * @param callback Function to be run after the component has been added to the DOM
    */
   onConnected(fn) {
     if (this.initialized) {
@@ -167,7 +172,10 @@ class Component extends WebComponent {
   }
 
   /**
-   * Enqueue a function to be run at the end of the components disconnectedCallback.
+   * Helper function which will queue a function to be run just before the component is
+   * removed from the DOM. This occurs during the disconnectedCallback lifecycle.
+   *
+   * @param callback Function to be run just before the component is removed from the DOM
    */
   onDisconnected(fn) {
     this._disconnectedQueue.push(fn);
@@ -349,7 +357,11 @@ class Component extends WebComponent {
 
     for (let i = 0; i < this._connectedQueue.length; i++) {
       const connectedCallbackFn = this._connectedQueue[i];
-      this._maybeEnqueueResult(connectedCallbackFn.call(this));
+      try {
+        this._maybeEnqueueResult(connectedCallbackFn.call(this));
+      } catch (err) {
+        console.warn(`error running onConnected function`, err);
+      }
     }
 
     this.initialized = true;
@@ -363,7 +375,11 @@ class Component extends WebComponent {
 
     for (let i = 0; i < this._disconnectedQueue.length; i++) {
       const disconnectedCallbackFn = this._disconnectedQueue[i];
-      disconnectedCallbackFn.call(this);
+      try {
+        disconnectedCallbackFn.call(this);
+      } catch (err) {
+        console.warn(`error running onDisconnected function`, err);
+      }
     }
 
     this._disconnectedQueue = this._disconnectedQueue.filter((fn) => !fn.removeAfterExec);

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -230,15 +230,12 @@ export class Component<StateT, AttrsT = AnyAttrs, AppStateT = unknown, AppT = un
    *
    * It can optionally return a function to be enqueued to be run just before the component is
    * removed from the DOM. This occurs during the disconnectedCallback lifecycle.
-   * @param callback Function to be run after the component has been added to the DOM
    */
   onConnected(callback: () => void | (() => void)): void;
 
   /**
    * Helper function which will queue a function to be run just before the component is
    * removed from the DOM. This occurs during the disconnectedCallback lifecycle.
-   *
-   * @param callback Function to be run just before the component is removed from the DOM
    */
   onDisconnected(callback: () => void): void;
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -225,10 +225,10 @@ export class Component<StateT, AttrsT = AnyAttrs, AppStateT = unknown, AppT = un
 
   /**
    * Helper function which will queue a function to be run once the component has been
-   * initialized and added to the DOM. If the component has already had it's connectedCallback
+   * initialized and added to the DOM. If the component has already had its connectedCallback
    * run, the function will run immediately.
    *
-   * It can optionally return a function to be queue'd to be run just before the component is
+   * It can optionally return a function to be enqueued to be run just before the component is
    * removed from the DOM. This occurs during the disconnectedCallback lifecycle.
    * @param callback Function to be run after the component has been added to the DOM
    */

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -222,4 +222,23 @@ export class Component<StateT, AttrsT = AnyAttrs, AppStateT = unknown, AppT = un
    * means of updating the DOM in a Panel application.
    */
   update(stateUpdate?: Partial<StateT> | ((state: StateT) => Partial<StateT>)): void;
+
+  /**
+   * Helper function which will queue a function to be run once the component has been
+   * initialized and added to the DOM. If the component has already had it's connectedCallback
+   * run, the function will run immediately.
+   *
+   * It can optionally return a function to be queue'd to be run just before the component is
+   * removed from the DOM. This occurs during the disconnectedCallback lifecycle.
+   * @param callback Function to be run after the component has been added to the DOM
+   */
+  onConnected(callback: () => void | (() => void)): void;
+
+  /**
+   * Helper function which will queue a function to be run just before the component is
+   * removed from the DOM. This occurs during the disconnectedCallback lifecycle.
+   *
+   * @param callback Function to be run just before the component is removed from the DOM
+   */
+  onDisconnected(callback: () => void): void;
 }

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -686,3 +686,68 @@ context(`$hooks`, function () {
     });
   });
 });
+
+describe.only(`Lifecycle Helpers`, function () {
+  let el;
+  let spy;
+
+  beforeEach(function () {
+    document.body.innerHTML = ``;
+    el = document.createElement(`simple-app`);
+    spy = sinon.spy();
+  });
+
+  it(`onConnected doesn't fire until connectedCallback`, async function () {
+    el.onConnected(spy);
+
+    expect(spy.callCount).to.equal(0);
+
+    document.body.appendChild(el);
+    await nextAnimationFrame();
+    expect(spy.callCount).to.equal(1);
+  });
+
+  it(`onConnected immediately fires if connectedCallback has run`, async function () {
+    document.body.appendChild(el);
+    await nextAnimationFrame();
+
+    el.onConnected(spy);
+    expect(spy.callCount).to.equal(1);
+  });
+
+  it(`onDisconnect fires on disconnectedCallback`, async function () {
+    document.body.appendChild(el);
+    await nextAnimationFrame();
+
+    el.onDisconnected(spy);
+    expect(spy.callCount).to.equal(0);
+
+    document.body.innerHTML = ``;
+    await nextAnimationFrame();
+    expect(spy.callCount).to.equal(1);
+  });
+
+  it(`onConnect can return a function to run on disconnectedCallback`, async function () {
+    document.body.appendChild(el);
+    await nextAnimationFrame();
+
+    el.onConnected(() => spy);
+    expect(spy.callCount).to.equal(0);
+
+    document.body.innerHTML = ``;
+    await nextAnimationFrame();
+    expect(spy.callCount).to.equal(1);
+  });
+
+  it(`onConnect function context is bound to the component`, async function () {
+    document.body.appendChild(el);
+    await nextAnimationFrame();
+
+    el.onConnected(function () {
+      this.update({baz: 42});
+    });
+    await nextAnimationFrame();
+
+    expect(el.textContent).to.contain(`baz: 42`);
+  });
+});

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -687,7 +687,7 @@ context(`$hooks`, function () {
   });
 });
 
-describe.only(`Lifecycle Helpers`, function () {
+describe(`Lifecycle Helpers`, function () {
   let el;
   let spy;
 

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -777,7 +777,7 @@ describe(`Lifecycle Helpers`, function () {
       expect(spy.callCount).to.equal(2);
     });
 
-    it(`returned function is called each time the component is removed from the DOM`, async function () {
+    it(`calls the returned function each time the component is removed from the DOM`, async function () {
       document.body.appendChild(el);
       await nextAnimationFrame();
 


### PR DESCRIPTION
Convenience methods for adding work to be run during the component's `connectedCallback` and `disconnectedCallback` lifecycle methods.

The primary purpose is to make the developer experience better when attaching and tearing down things like event listeners and subscriptions.

`onDisconnected` can be used in a `connectedCallback` to remove attached listeners

Eg:

```ts
connectedCallback() {
if (this.attr(`multi-select`)) {
  // to show shift+click range select feedback
  document.body.addEventListener(`keydown`, this.helpers.shiftKeyListener);
  document.body.addEventListener(`keyup`, this.helpers.shiftKeyListener);
  this.onDisconnected(() => {
    document.body.removeEventListener(`keydown`, this.helpers.shiftKeyListener);
    document.body.removeEventListener(`keyup`, this.helpers.shiftKeyListener);
  });
}
}
```

It also can help ensure that we don't have to store references to the listeners outside `connectedCallback` by leveraging closures

```ts
  connectedCallback() {
    super.connectedCallback();

    const handleResize = () =>
      requestAnimationFrame(() => {
        if (this.tableElement) {
          this.calculateFlowLinks();
        }
      });
    window.addEventListener(`resize`, handleResize);
    this.onDisconnected(() => window.removeEventListener(`resize`, handleResize));

  }
```

`onConnected` is a similar function that can setup and teardown listeners or subscriptions from a constructor. It can also be used by an outside observer like in tests. This use-case is less of an immediate need but felt like the sibling functionality to `onDisconnected`.