### PR TITLE
Thoroughly walk DOM subtrees to trigger connected/disconected lifecycle in isorender DOM shims

### DIFF
--- a/lib/isorender/dom-shims.js
+++ b/lib/isorender/dom-shims.js
@@ -27,6 +27,7 @@ import requestAnimationFrame from 'raf';
 // is already there
 global.requestAnimationFrame = global.requestAnimationFrame || requestAnimationFrame;
 
+// run a callback for every node of the DOM (sub)tree rooted at the given root node
 function walkDomTree(root, callback) {
   // basic breadth-first tree traversal (non-recursive)
   const breadthQueue = [root];

--- a/lib/isorender/dom-shims.js
+++ b/lib/isorender/dom-shims.js
@@ -33,9 +33,13 @@ function walkDomTree(root, callback) {
   while (breadthQueue.length > 0) {
     const node = breadthQueue.shift();
     callback(node);
-    const children = node.shadowRoot ? node.shadowRoot.childNodes : node.childNodes;
-    for (const child of Array.from(children || [])) {
+    for (const child of Array.from(node.childNodes || [])) {
       breadthQueue.push(child);
+    }
+    if (node.shadowRoot) {
+      for (const child of Array.from(node.shadowRoot.childNodes || [])) {
+        breadthQueue.push(child);
+      }
     }
   }
 }

--- a/lib/isorender/dom-shims.js
+++ b/lib/isorender/dom-shims.js
@@ -28,7 +28,6 @@ import requestAnimationFrame from 'raf';
 global.requestAnimationFrame = global.requestAnimationFrame || requestAnimationFrame;
 
 function walkDomTree(root, callback) {
-  // recursively connect elements to the DOM
   // basic breadth-first tree traversal (non-recursive)
   const breadthQueue = [root];
   while (breadthQueue.length > 0) {

--- a/lib/isorender/dom-shims.js
+++ b/lib/isorender/dom-shims.js
@@ -27,17 +27,32 @@ import requestAnimationFrame from 'raf';
 // is already there
 global.requestAnimationFrame = global.requestAnimationFrame || requestAnimationFrame;
 
+function walkDomTree(root, callback) {
+  // recursively connect elements to the DOM
+  // basic breadth-first tree traversal (non-recursive)
+  const breadthQueue = [root];
+  while (breadthQueue.length > 0) {
+    const node = breadthQueue.shift();
+    callback(node);
+    for (const child of Array.from(node.childNodes || [])) {
+      breadthQueue.push(child);
+    }
+  }
+}
+
 // patch DOM insertion functions to call connectedCallback on Custom Elements
 [`appendChild`, `insertBefore`, `replaceChild`].forEach((funcName) => {
   const origFunc = Element.prototype[funcName];
   Element.prototype[funcName] = function () {
     const child = origFunc.apply(this, arguments);
-    requestAnimationFrame(() => {
-      if (!child.initialized && child.connectedCallback) {
-        child.isConnected = true;
-        child.connectedCallback();
-      }
-    });
+    if (this.isConnected) {
+      walkDomTree(child, function (node) {
+        node.isConnected = true;
+        if (node.connectedCallback) {
+          node.connectedCallback();
+        }
+      });
+    }
   };
 });
 
@@ -45,10 +60,13 @@ global.requestAnimationFrame = global.requestAnimationFrame || requestAnimationF
 const origRemoveChild = Element.prototype.removeChild;
 Element.prototype.removeChild = function (child) {
   origRemoveChild.call(this, child);
-  const childNode = child;
-  if (childNode && childNode.disconnectedCallback && childNode.initialized) {
-    childNode.isConnected = false;
-    childNode.disconnectedCallback();
+  if (this.isConnected) {
+    walkDomTree(child, function (node) {
+      node.isConnected = false;
+      if (node.disconnectedCallback) {
+        node.disconnectedCallback();
+      }
+    });
   }
   return child;
 };
@@ -112,6 +130,9 @@ Document.prototype.createElement = function (tagName) {
     el.nodeName = el.tagName = tagName;
   } else {
     el = originalCreateElement(...arguments);
+  }
+  if (tagName === `body`) {
+    el.isConnected = true;
   }
   return el;
 };

--- a/lib/isorender/dom-shims.js
+++ b/lib/isorender/dom-shims.js
@@ -51,9 +51,11 @@ function walkDomTree(root, callback) {
     const child = origFunc.apply(this, arguments);
     if (this.isConnected) {
       walkDomTree(child, function (node) {
-        node.isConnected = true;
-        if (node.connectedCallback) {
-          node.connectedCallback();
+        if (!node.isConnected) {
+          node.isConnected = true;
+          if (node.connectedCallback) {
+            node.connectedCallback();
+          }
         }
       });
     }
@@ -66,9 +68,11 @@ Element.prototype.removeChild = function (child) {
   origRemoveChild.call(this, child);
   if (this.isConnected) {
     walkDomTree(child, function (node) {
-      node.isConnected = false;
-      if (node.disconnectedCallback) {
-        node.disconnectedCallback();
+      if (node.isConnected) {
+        node.isConnected = false;
+        if (node.disconnectedCallback) {
+          node.disconnectedCallback();
+        }
       }
     });
   }

--- a/lib/isorender/dom-shims.js
+++ b/lib/isorender/dom-shims.js
@@ -34,7 +34,8 @@ function walkDomTree(root, callback) {
   while (breadthQueue.length > 0) {
     const node = breadthQueue.shift();
     callback(node);
-    for (const child of Array.from(node.childNodes || [])) {
+    const children = node.shadowRoot ? node.shadowRoot.childNodes : node.childNodes;
+    for (const child of Array.from(children || [])) {
       breadthQueue.push(child);
     }
   }

--- a/lib/isorender/dom-shims.js
+++ b/lib/isorender/dom-shims.js
@@ -97,6 +97,9 @@ class HTMLElement extends Element {
     this.shadowRoot = document.createElement(`shadow-root`);
     this.shadowRoot.nodeType = Node.DOCUMENT_FRAGMENT_NODE;
     this.shadowRoot.host = this;
+    if (this.isConnected) {
+      this.shadowRoot.isConnected = true;
+    }
     return this.shadowRoot;
   }
 

--- a/test/server/component.js
+++ b/test/server/component.js
@@ -29,6 +29,10 @@ customElements.define(`dark-app`, DarkApp);
 customElements.define(`themed-widget`, ThemedWidget);
 
 describe(`Server-side component renderer`, function () {
+  beforeEach(function () {
+    document.body = document.createElement(`body`);
+  });
+
   it(`can register and create components with document.createElement`, function () {
     const el = document.createElement(`simple-app`);
     expect(el.state).to.eql({foo: `bar`, baz: `qux`});
@@ -68,7 +72,6 @@ describe(`Server-side component renderer`, function () {
   });
 
   it(`renders nested components`, async function () {
-    document.body = document.createElement(`body`);
     const el = new NestedApp();
     document.body.appendChild(el);
 
@@ -95,7 +98,6 @@ describe(`Server-side component renderer`, function () {
   });
 
   it(`updates nested components`, async function () {
-    document.body = document.createElement(`body`);
     const el = new NestedApp();
     document.body.appendChild(el);
 
@@ -239,36 +241,34 @@ describe(`Server-side component renderer`, function () {
       document.createElement(`bad-boolean-required-attrs-schema-app`);
     }).to.throw(/boolean attr 'bool-attr' cannot have required or default/);
   });
-});
 
-// TODO: add more server-side context test cases
-describe(`Component with contexts`, function () {
-  context(`getContext()`, function () {
-    it(`returns own default context without context ancestor`, async function () {
-      document.body = document.createElement(`body`);
-      const widget = document.createElement(`default-light-themed-widget`);
-      document.body.appendChild(widget);
-      await nextAnimationFrame();
-      expect(widget.getContext(`theme`)).to.be.an.instanceof(LightTheme);
-      expect(widget.el.childNodes[0].className).to.equal(`light`);
-    });
-  });
-
-  context(`lifecycle`, function () {
-    it(`fails to connect when a context declared in config does not have a default context by itself or from any context ancestor`, async function () {
-      document.body = document.createElement(`body`);
-      const errors = [];
-      const widget = document.createElement(`themed-widget`);
-
-      try {
+  // TODO: add more server-side context test cases
+  describe(`Component with contexts`, function () {
+    context(`getContext()`, function () {
+      it(`returns own default context without context ancestor`, async function () {
+        const widget = document.createElement(`default-light-themed-widget`);
         document.body.appendChild(widget);
         await nextAnimationFrame();
-      } catch (err) {
-        errors.push(err.message);
-      }
+        expect(widget.getContext(`theme`)).to.be.an.instanceof(LightTheme);
+        expect(widget.el.childNodes[0].className).to.equal(`light`);
+      });
+    });
 
-      expect(errors).to.have.lengthOf(1);
-      expect(errors[0]).to.contain(`A "theme" context is not available`);
+    context(`lifecycle`, function () {
+      it(`fails to connect when a context declared in config does not have a default context by itself or from any context ancestor`, async function () {
+        const errors = [];
+        const widget = document.createElement(`themed-widget`);
+
+        try {
+          document.body.appendChild(widget);
+          await nextAnimationFrame();
+        } catch (err) {
+          errors.push(err.message);
+        }
+
+        expect(errors).to.have.lengthOf(1);
+        expect(errors[0]).to.contain(`A "theme" context is not available`);
+      });
     });
   });
 });

--- a/test/server/component.js
+++ b/test/server/component.js
@@ -68,8 +68,9 @@ describe(`Server-side component renderer`, function () {
   });
 
   it(`renders nested components`, async function () {
+    document.body = document.createElement(`body`);
     const el = new NestedApp();
-    el.connectedCallback();
+    document.body.appendChild(el);
 
     await nextAnimationFrame();
 
@@ -94,8 +95,9 @@ describe(`Server-side component renderer`, function () {
   });
 
   it(`updates nested components`, async function () {
+    document.body = document.createElement(`body`);
     const el = new NestedApp();
-    el.connectedCallback();
+    document.body.appendChild(el);
 
     await nextAnimationFrame();
 
@@ -243,8 +245,9 @@ describe(`Server-side component renderer`, function () {
 describe(`Component with contexts`, function () {
   context(`getContext()`, function () {
     it(`returns own default context without context ancestor`, async function () {
+      document.body = document.createElement(`body`);
       const widget = document.createElement(`default-light-themed-widget`);
-      document.createElement(`div`).appendChild(widget);
+      document.body.appendChild(widget);
       await nextAnimationFrame();
       expect(widget.getContext(`theme`)).to.be.an.instanceof(LightTheme);
       expect(widget.el.childNodes[0].className).to.equal(`light`);
@@ -253,13 +256,13 @@ describe(`Component with contexts`, function () {
 
   context(`lifecycle`, function () {
     it(`fails to connect when a context declared in config does not have a default context by itself or from any context ancestor`, async function () {
+      document.body = document.createElement(`body`);
       const errors = [];
       const widget = document.createElement(`themed-widget`);
-      document.createElement(`div`).appendChild(widget);
-      await nextAnimationFrame();
 
       try {
-        widget.getContext(`theme`);
+        document.body.appendChild(widget);
+        await nextAnimationFrame();
       } catch (err) {
         errors.push(err.message);
       }

--- a/test/server/dom-shims.js
+++ b/test/server/dom-shims.js
@@ -54,14 +54,14 @@ describe(`customElement callbacks`, function () {
     expect(elem.isConnected).to.not.exist;
 
     // fake adding to DOM
-    const parent = document.createElement(`div`);
-    parent.appendChild(elem);
+    document.body = document.createElement(`body`);
+    document.body.appendChild(elem);
 
     await nextAnimationFrame();
     expect(connectedCallbackSpy).to.have.been.called;
     expect(elem.isConnected).to.be.true;
 
-    parent.removeChild(elem);
+    document.body.removeChild(elem);
     expect(disconnectedCallbackSpy).to.have.been.called;
   });
 


### PR DESCRIPTION
The current dom-shim always connects an element during `appendChild`, which shouldn't be semantically correct. A real browser won't connect an element until the whole element subtree is appended to a parent that is already connected, at which point the browser will start traversing the subtree starting from the subtree's root to invoke `connectedCallback` on each node.

In real browsers, the document body is always connected. In the shims we should do the same: the `<body>` tag is considered "always connected" and elements must be appended to a body tag (there should only be one body tag) to trigger the connected lifecycle.

~It's currently an experimental WIP prototype because it seems to break many iso tests in the private mixpanel repo which I have not yet finished investigating; I'm not sure if that is caused by those iso tests relying on incorrect semantics or if these dom-shim changes are behaving incorrectly.~

Note: this is intended to fix errors that are appearing when integrating components that use Contexts into iso tests.