### PR TITLE
Fixes for special cases around root node in template

### DIFF
--- a/lib/dom-patcher.js
+++ b/lib/dom-patcher.js
@@ -56,6 +56,7 @@ export class DOMPatcher {
         insertHook(this.vnode);
       }
     }
+    this.el = this.vnode.elm;
   }
 
   update(newState) {
@@ -91,6 +92,7 @@ export class DOMPatcher {
 
     patch(this.vnode, newVnode);
     this.vnode = newVnode;
+    this.el = this.vnode.elm;
   }
 
   disconnect() {
@@ -101,6 +103,6 @@ export class DOMPatcher {
     this.el = null;
     // patch with empty vnode to clear out listeners in tree
     // this ensures we don't leave dangling DetachedHTMLElements blocking GC
-    patch(vnode, {sel: vnode.sel});
+    patch(vnode, {sel: vnode.sel, key: vnode.key});
   }
 }

--- a/lib/dom-patcher.js
+++ b/lib/dom-patcher.js
@@ -47,6 +47,15 @@ export class DOMPatcher {
     }
 
     patch(this.el, this.vnode);
+    if (this.el === this.vnode.elm) {
+      const insertHook = this.vnode.data.hook && this.vnode.data.hook.insert;
+      if (insertHook) {
+        // since Snabbdom recycled our newly-created root element (this.el) rather
+        // than creating its own element, it doesn't fire the insert hook, so we're
+        // going to fake it out and call it ourselves
+        insertHook(this.vnode);
+      }
+    }
   }
 
   update(newState) {

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -146,12 +146,21 @@ describe(`Simple Component instance`, function () {
       expect(el.postFoo).to.equal(`llamas`);
     });
 
-    describe(`Snabbdom insert hook`, function () {
-      it(`fires when the root element gets patched in place instead of inserted`, function () {
+    context(`root element special cases`, function () {
+      it(`fires Snabbdom insert hook when the root element gets patched in place instead of inserted`, function () {
         el = document.createElement(`insert-hook-without-key`);
         expect(el.insertHookCalled).not.to.be.ok;
         document.body.appendChild(el);
         expect(el.insertHookCalled).to.be.true;
+      });
+
+      it(`uses Snabbdom's new root element if the patch process creates one`, async function () {
+        el = document.createElement(`insert-hook-with-key`);
+        expect(el.insertHookCalled).not.to.be.ok;
+        document.body.appendChild(el);
+        expect(el.insertHookCalled).to.be.true;
+        await nextAnimationFrame();
+        expect(el.textContent).to.contain(`Hello I'm in a keyed root element`);
       });
     });
   });

--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -145,6 +145,15 @@ describe(`Simple Component instance`, function () {
       expect(el.preFoo).to.equal(`bar`);
       expect(el.postFoo).to.equal(`llamas`);
     });
+
+    describe(`Snabbdom insert hook`, function () {
+      it(`fires when the root element gets patched in place instead of inserted`, function () {
+        el = document.createElement(`insert-hook-without-key`);
+        expect(el.insertHookCalled).not.to.be.ok;
+        document.body.appendChild(el);
+        expect(el.insertHookCalled).to.be.true;
+      });
+    });
   });
 
   context(`when detached from DOM`, function () {

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -9,6 +9,7 @@ import {NestedPartialStateParent, NestedPartialStateChild} from './nested-partia
 import {BadBooleanRequiredAttrsSchemaApp, RequiredAttrsSchemaApp} from './required-attrs-schema-apps';
 import {ShadowDomApp} from './shadow-dom-app';
 import {SimpleApp} from './simple-app';
+import {InsertHookWithoutKey, InsertHookWithKey} from './snabbdom-hooks-components';
 import {
   DefaultLightThemedWidget,
   ThemedWidget,
@@ -27,6 +28,8 @@ customElements.define(`bad-required-attrs-schema-app`, BadBooleanRequiredAttrsSc
 customElements.define(`breakable-app`, BreakableApp);
 customElements.define(`css-no-shadow-app`, CssNoShadowApp);
 customElements.define(`delayed-attr-remove-app`, DelayedAttrRemoveApp);
+customElements.define(`insert-hook-without-key`, InsertHookWithoutKey);
+customElements.define(`insert-hook-with-key`, InsertHookWithKey);
 customElements.define(`nested-app`, NestedApp);
 customElements.define(`nested-child`, NestedChild);
 customElements.define(`nested-keyed-children-app`, NestedKeyedChildrenApp);

--- a/test/fixtures/snabbdom-hooks-components.js
+++ b/test/fixtures/snabbdom-hooks-components.js
@@ -1,0 +1,39 @@
+import {Component, h} from '../../lib';
+
+export class InsertHookWithoutKey extends Component {
+  get config() {
+    return {
+      template: () =>
+        h(
+          `div`,
+          {
+            hook: {
+              insert: () => (this.insertHookCalled = true),
+            },
+          },
+          [h(`p`, `Hello`)],
+        ),
+    };
+  }
+}
+
+export class InsertHookWithKey extends Component {
+  get config() {
+    return {
+      template: () =>
+        h(
+          `div`,
+          {
+            // because of the key, Snabbdom will create a new element
+            // rather than patching Panel's existing root element in
+            // place
+            key: `foobar`,
+            hook: {
+              insert: () => (this.insertHookCalled = true),
+            },
+          },
+          [h(`p`, `Hello I'm in a keyed root element`)],
+        ),
+    };
+  }
+}


### PR DESCRIPTION
- If Snabbdom creates a new top-level element rather than patching DOMPatcher's existing element (for instance, when a `key` or tag change forces the creation of a new element), update DOMPatcher's internal element reference to point to it
- If Snabbdom recycles the existing top-level element that DOMPatcher newly created, it won't fire the `insert` hook since it didn't insert any new element into the DOM, so we run the hook from DOMPatcher directly if it's been set on the root node