### PR TITLE
Support Constructible Stylesheets in webpack hot module style loader

### DIFF
--- a/hot/style-loader.js
+++ b/hot/style-loader.js
@@ -20,21 +20,7 @@ module.exports.pitch = function (request) {
       const updatePanelElems = require('panel/hot/update-panel-elems');
       updatePanelElems('${elemName}', elem => {
         if (elem.getConfig('useShadowDom')) {
-          const newStyleText = newStyle.toString();
-          if (elem.el.adoptedStyleSheets) {
-            if (!elem.configStyleSheet) {
-              elem.configStyleSheet = new CSSStyleSheet();
-              elem.el.adoptedStyleSheets = [elem.configStyleSheet, ...this.el.adoptedStyleSheets.slice(1)];
-            }
-            elem.configStyleSheet.replaceSync(newStyleText);
-            elem.setCachedStyleSheet(elem.configStyleSheet);
-          } else {
-            if (!elem.configStyleTag) {
-              elem.configStyleTag = document.createElement('style');
-              elem.el.prepend(elem.configStyleTag);
-            }
-            elem.configStyleTag.textContent = newStyleText;
-          }
+          elem.applyStaticStyle(newStyle.toString(), /* ignoreCache */ true);
           return true;
         }
       });

--- a/hot/style-loader.js
+++ b/hot/style-loader.js
@@ -22,17 +22,18 @@ module.exports.pitch = function (request) {
         if (elem.getConfig('useShadowDom')) {
           const newStyleText = newStyle.toString();
           if (elem.el.adoptedStyleSheets) {
-            if (!elem.getConfig('css')) {
-              const newStylesheet = new CSSStyleSheet();
-              elem.el.adoptedStyleSheets = [newStylesheet, ...elem.el.adoptedStyleSheets.slice(1)];
+            if (!elem.configStyleSheet) {
+              elem.configStyleSheet = new CSSStyleSheet();
+              elem.el.adoptedStyleSheets = [elem.configStyleSheet, ...this.el.adoptedStyleSheets.slice(1)];
             }
-            if (newStyleText) {
-              elem.el.adoptedStyleSheets[0].replaceSync(newStyleText);
-            } else {
-              elem.el.adoptedStyleSheets = elem.el.adoptedStyleSheets.slice(1);
-            }
+            elem.configStyleSheet.replaceSync(newStyleText);
+            elem.setCachedStyleSheet(elem.configStyleSheet);
           } else {
-            elem.el.querySelector('style').textContent = newStyleText;
+            if (!elem.configStyleTag) {
+              elem.configStyleTag = document.createElement('style');
+              elem.el.appendChild(elem.configStyleTag);
+            }
+            elem.configStyleTag.textContent = newStyleText;
           }
           return true;
         }

--- a/hot/style-loader.js
+++ b/hot/style-loader.js
@@ -20,7 +20,18 @@ module.exports.pitch = function (request) {
       const updatePanelElems = require('panel/hot/update-panel-elems');
       updatePanelElems('${elemName}', elem => {
         if (elem.getConfig('useShadowDom')) {
-          elem.el.querySelector('style').textContent = newStyle.toString();
+          const newStyleText = newStyle.toString();
+          if (elem.el.adoptedStyleSheets) {
+            if (newStyleText) {
+              const newStylesheet = new CSSStyleSheet();
+              newStylesheet.replaceSync(newStyleText);
+              elem.el.adoptedStyleSheets = [newStylesheet, ...elem.el.adoptedStyleSheets.slice(1)];
+            } else if (elem.getConfig('css')) {
+              elem.el.adoptedStyleSheets = elem.el.adoptedStyleSheets.slice(1);
+            }
+          } else {
+            elem.el.querySelector('style').textContent = newStyleText;
+          }
           return true;
         }
       });

--- a/hot/style-loader.js
+++ b/hot/style-loader.js
@@ -20,7 +20,7 @@ module.exports.pitch = function (request) {
       const updatePanelElems = require('panel/hot/update-panel-elems');
       updatePanelElems('${elemName}', elem => {
         if (elem.getConfig('useShadowDom')) {
-          elem.applyStaticStyle(newStyle.toString(), /* ignoreCache */ true);
+          elem.applyStaticStyle(newStyle.toString(), {ignoreCache: true});
           return true;
         }
       });

--- a/hot/style-loader.js
+++ b/hot/style-loader.js
@@ -31,7 +31,7 @@ module.exports.pitch = function (request) {
           } else {
             if (!elem.configStyleTag) {
               elem.configStyleTag = document.createElement('style');
-              elem.el.appendChild(elem.configStyleTag);
+              elem.el.prepend(elem.configStyleTag);
             }
             elem.configStyleTag.textContent = newStyleText;
           }

--- a/hot/style-loader.js
+++ b/hot/style-loader.js
@@ -22,11 +22,13 @@ module.exports.pitch = function (request) {
         if (elem.getConfig('useShadowDom')) {
           const newStyleText = newStyle.toString();
           if (elem.el.adoptedStyleSheets) {
-            if (newStyleText) {
+            if (!elem.getConfig('css')) {
               const newStylesheet = new CSSStyleSheet();
-              newStylesheet.replaceSync(newStyleText);
               elem.el.adoptedStyleSheets = [newStylesheet, ...elem.el.adoptedStyleSheets.slice(1)];
-            } else if (elem.getConfig('css')) {
+            }
+            if (newStyleText) {
+              elem.el.adoptedStyleSheets[0].replaceSync(newStyleText);
+            } else {
               elem.el.adoptedStyleSheets = elem.el.adoptedStyleSheets.slice(1);
             }
           } else {

--- a/hot/update-panel-elems.js
+++ b/hot/update-panel-elems.js
@@ -34,7 +34,7 @@ module.exports = function updatePanelElems(elemName, updateFn) {
     console.info(`[HMR Panel] Updated ${elems.length} ${elemName} elems`);
   } else if (!elems.length) {
     console.warn(`[HMR Panel] No ${elemName} elems found`);
-    console.warn(`[HMR Panel] Exepect file path to be '.../<elemName>/index.<ext>' or '.../<elemName>.<ext>'`);
+    console.warn(`[HMR Panel] Expect file path to be '.../<elemName>/index.<ext>' or '.../<elemName>.<ext>'`);
   }
 
   return numUpdated;

--- a/lib/component.js
+++ b/lib/component.js
@@ -323,18 +323,17 @@ class Component extends WebComponent {
         if (this.el.adoptedStyleSheets) {
           // Attempt to cache the styles using Constructible StyleSheets if the feature is supported.
           // Note: this technique avoids the Flash of Unstyled Content that alternative approaches like <link> tags will encounter
-          const componentKey = this.constructor;
-          let stylesheet = stylesheetCache.get(componentKey);
-          if (!stylesheet) {
-            stylesheet = new CSSStyleSheet();
-            stylesheet.replaceSync(css);
-            stylesheetCache.set(componentKey, stylesheet);
+          this.configStyleSheet = this.getCachedStyleSheet();
+          if (!this.configStyleSheet) {
+            this.configStyleSheet = new CSSStyleSheet();
+            this.configStyleSheet.replaceSync(css);
+            this.setCachedStyleSheet(this.configStyleSheet);
           }
-          this.el.adoptedStyleSheets = [stylesheet];
+          this.el.adoptedStyleSheets = [this.configStyleSheet];
         } else {
-          const styleTag = document.createElement(`style`);
-          styleTag.innerHTML = css;
-          this.el.appendChild(styleTag);
+          this.configStyleTag = document.createElement(`style`);
+          this.configStyleTag.innerHTML = css;
+          this.el.appendChild(this.configStyleTag);
         }
       }
     } else if (this.getConfig(`css`)) {
@@ -573,6 +572,14 @@ class Component extends WebComponent {
     if (this.initialized) {
       this.update();
     }
+  }
+
+  getCachedStyleSheet() {
+    return stylesheetCache.get(this.constructor);
+  }
+
+  setCachedStyleSheet(styleSheet) {
+    stylesheetCache.set(this.constructor, styleSheet);
   }
 
   _applyStyleOverride(styleOverride) {

--- a/lib/component.js
+++ b/lib/component.js
@@ -577,7 +577,7 @@ class Component extends WebComponent {
       } else {
         if (!this.staticStyleTag) {
           this.staticStyleTag = document.createElement(`style`);
-          this.el.insertBefore(this.staticStyleTag, this.el.childNodes[0]);
+          this.el.insertBefore(this.staticStyleTag, this.el.childNodes[0] || null);
         }
         this.staticStyleTag.innerHTML = styleSheetText;
       }

--- a/lib/component.js
+++ b/lib/component.js
@@ -317,7 +317,7 @@ class Component extends WebComponent {
 
     if (this.getConfig(`useShadowDom`)) {
       this.el = this.attachShadow({mode: `open`});
-      this.applyStaticStyle(this.getConfig(`css`), /* ignoreCache */ false);
+      this.applyStaticStyle(this.getConfig(`css`));
     } else if (this.getConfig(`css`)) {
       throw Error(`"useShadowDom" config option must be set in order to use "css" config.`);
     } else {
@@ -556,7 +556,7 @@ class Component extends WebComponent {
     }
   }
 
-  applyStaticStyle(styleSheetText, ignoreCache) {
+  applyStaticStyle(styleSheetText, {ignoreCache} = {ignoreCache: false}) {
     if (styleSheetText) {
       if (this.el.adoptedStyleSheets) {
         // Attempt to cache the styles using Constructible StyleSheets if the feature is supported.

--- a/lib/component.js
+++ b/lib/component.js
@@ -577,7 +577,7 @@ class Component extends WebComponent {
       } else {
         if (!this.staticStyleTag) {
           this.staticStyleTag = document.createElement(`style`);
-          this.el.prepend(this.staticStyleTag);
+          this.el.insertBefore(this.staticStyleTag, this.el.childNodes[0]);
         }
         this.staticStyleTag.innerHTML = styleSheetText;
       }

--- a/lib/component.js
+++ b/lib/component.js
@@ -317,25 +317,7 @@ class Component extends WebComponent {
 
     if (this.getConfig(`useShadowDom`)) {
       this.el = this.attachShadow({mode: `open`});
-
-      const css = this.getConfig(`css`);
-      if (css) {
-        if (this.el.adoptedStyleSheets) {
-          // Attempt to cache the styles using Constructible StyleSheets if the feature is supported.
-          // Note: this technique avoids the Flash of Unstyled Content that alternative approaches like <link> tags will encounter
-          this.configStyleSheet = this.getCachedStyleSheet();
-          if (!this.configStyleSheet) {
-            this.configStyleSheet = new CSSStyleSheet();
-            this.configStyleSheet.replaceSync(css);
-            this.setCachedStyleSheet(this.configStyleSheet);
-          }
-          this.el.adoptedStyleSheets = [this.configStyleSheet];
-        } else {
-          this.configStyleTag = document.createElement(`style`);
-          this.configStyleTag.innerHTML = css;
-          this.el.appendChild(this.configStyleTag);
-        }
-      }
+      this.applyStaticStyle(this.getConfig(`css`), /* ignoreCache */ false);
     } else if (this.getConfig(`css`)) {
       throw Error(`"useShadowDom" config option must be set in order to use "css" config.`);
     } else {
@@ -574,12 +556,32 @@ class Component extends WebComponent {
     }
   }
 
-  getCachedStyleSheet() {
-    return stylesheetCache.get(this.constructor);
-  }
-
-  setCachedStyleSheet(styleSheet) {
-    stylesheetCache.set(this.constructor, styleSheet);
+  applyStaticStyle(styleSheetText, ignoreCache) {
+    if (styleSheetText) {
+      if (this.el.adoptedStyleSheets) {
+        // Attempt to cache the styles using Constructible StyleSheets if the feature is supported.
+        // Note: this technique avoids the Flash of Unstyled Content that alternative approaches like <link> tags will encounter
+        const componentKey = this.constructor;
+        let cachedStyleSheet = stylesheetCache.get(componentKey);
+        if (!cachedStyleSheet) {
+          cachedStyleSheet = new CSSStyleSheet();
+          cachedStyleSheet.replaceSync(styleSheetText);
+          stylesheetCache.set(componentKey, cachedStyleSheet);
+        } else if (ignoreCache) {
+          cachedStyleSheet.replaceSync(styleSheetText);
+        }
+        if (!this.staticStyleSheet) {
+          this.staticStyleSheet = cachedStyleSheet;
+          this.el.adoptedStyleSheets = [this.staticStyleSheet, ...this.el.adoptedStyleSheets.slice(1)];
+        }
+      } else {
+        if (!this.staticStyleTag) {
+          this.staticStyleTag = document.createElement(`style`);
+          this.el.prepend(this.staticStyleTag);
+        }
+        this.staticStyleTag.innerHTML = styleSheetText;
+      }
+    }
   }
 
   _applyStyleOverride(styleOverride) {

--- a/lib/component.js
+++ b/lib/component.js
@@ -556,7 +556,7 @@ class Component extends WebComponent {
     }
   }
 
-  applyStaticStyle(styleSheetText, {ignoreCache} = {ignoreCache: false}) {
+  applyStaticStyle(styleSheetText, {ignoreCache = false} = {}) {
     if (styleSheetText) {
       if (this.el.adoptedStyleSheets) {
         // Attempt to cache the styles using Constructible StyleSheets if the feature is supported.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -200,10 +200,10 @@ export class Component<
   /** style-override attribute's stylesheet if Constructible StyleSheets is supported */
   styleOverrideStyleSheet?: CSSStyleSheet;
 
-  /** Static stylesheet if Constructible StyleSheets is supported */
+  /** Static style tag if Constructible StyleSheets is not supported */
   staticStyleTag?: Element;
 
-  /** style-override attribute's stylesheet if Constructible StyleSheets is not supported */
+  /** style-override attribute's style tag if Constructible StyleSheets is not supported */
   styleOverrideTag?: Element;
 
   /** Applies the static stylesheet for this component class */

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -207,7 +207,7 @@ export class Component<
   styleOverrideTag?: Element;
 
   /** Applies the static stylesheet for this component class */
-  applyStaticStyle(styleSheetText: null | string, options: {ignoreCache: boolean}): void;
+  applyStaticStyle(styleSheetText: null | string, options?: {ignoreCache: boolean}): void;
 
   /** Defines standard component configuration */
   get config(): ConfigOptions<StateT, AppStateT, ContextRegistryT>;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -194,18 +194,6 @@ export class Component<
     lastRenderAt: number;
   }>;
 
-  /** Static stylesheet if Constructible StyleSheets is supported */
-  staticStyleSheet?: CSSStyleSheet;
-
-  /** style-override attribute's stylesheet if Constructible StyleSheets is supported */
-  styleOverrideStyleSheet?: CSSStyleSheet;
-
-  /** Static style tag if Constructible StyleSheets is not supported */
-  staticStyleTag?: Element;
-
-  /** style-override attribute's style tag if Constructible StyleSheets is not supported */
-  styleOverrideTag?: Element;
-
   /** Applies the static stylesheet for this component class */
   applyStaticStyle(styleSheetText: null | string, options?: {ignoreCache: boolean}): void;
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -207,7 +207,7 @@ export class Component<
   styleOverrideTag?: Element;
 
   /** Applies the static stylesheet for this component class */
-  applyStaticStyle(styleSheetText: null | string, ignoreCache: boolean): void;
+  applyStaticStyle(styleSheetText: null | string, options: {ignoreCache: boolean}): void;
 
   /** Defines standard component configuration */
   get config(): ConfigOptions<StateT, AppStateT, ContextRegistryT>;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -195,22 +195,19 @@ export class Component<
   }>;
 
   /** Static stylesheet if Constructible StyleSheets is supported */
-  configStyleSheet?: CSSStyleSheet;
+  staticStyleSheet?: CSSStyleSheet;
 
   /** style-override attribute's stylesheet if Constructible StyleSheets is supported */
   styleOverrideStyleSheet?: CSSStyleSheet;
 
   /** Static stylesheet if Constructible StyleSheets is supported */
-  configStyleTag?: Element;
+  staticStyleTag?: Element;
 
   /** style-override attribute's stylesheet if Constructible StyleSheets is not supported */
   styleOverrideTag?: Element;
 
-  /** Gets the cached static stylesheet for this component class */
-  getCachedStyleSheet(): CSSStyleSheet | undefined;
-
-  /** Sets the cached static stylesheet for this component class */
-  setCachedStyleSheet(styleSheet: CSSStyleSheet): void;
+  /** Applies the static stylesheet for this component class */
+  applyStaticStyle(styleSheetText: null | string, ignoreCache: boolean): void;
 
   /** Defines standard component configuration */
   get config(): ConfigOptions<StateT, AppStateT, ContextRegistryT>;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -194,6 +194,24 @@ export class Component<
     lastRenderAt: number;
   }>;
 
+  /** Static stylesheet if Constructible StyleSheets is supported */
+  configStyleSheet?: CSSStyleSheet;
+
+  /** style-override attribute's stylesheet if Constructible StyleSheets is supported */
+  styleOverrideStyleSheet?: CSSStyleSheet;
+
+  /** Static stylesheet if Constructible StyleSheets is supported */
+  configStyleTag?: Element;
+
+  /** style-override attribute's stylesheet if Constructible StyleSheets is not supported */
+  styleOverrideTag?: Element;
+
+  /** Gets the cached static stylesheet for this component class */
+  getCachedStyleSheet(): CSSStyleSheet | undefined;
+
+  /** Sets the cached static stylesheet for this component class */
+  setCachedStyleSheet(styleSheet: CSSStyleSheet): void;
+
   /** Defines standard component configuration */
   get config(): ConfigOptions<StateT, AppStateT, ContextRegistryT>;
 


### PR DESCRIPTION
https://github.com/mixpanel/panel/pull/138 broke the webpack hot module style loader which relied on the existence of a `<style>` tag.