### PR TITLE
Test stability: use specific CSS rule in browser tests to avoid CSS stylesheet expansion

### DIFF
--- a/test/browser/component.js
+++ b/test/browser/component.js
@@ -321,15 +321,15 @@ describe(`Simple Component instance`, function () {
 
     context(`when applying override styles`, function () {
       it(`appends the overriding styles to the default styles`, async function () {
-        el.setAttribute(`style-override`, `:host { background: red; }`);
+        el.setAttribute(`style-override`, `:host { background-color: red; }`);
         await nextAnimationFrame();
-        expect(getComponentStylesheetText(el)).to.equal(`:host { color: blue; }:host { background: red; }`);
+        expect(getComponentStylesheetText(el)).to.equal(`:host { color: blue; }:host { background-color: red; }`);
       });
 
       it(`it applies the styles even if the component isn't attached to the DOM`, function () {
         el = document.createElement(`shadow-dom-app`);
-        el.setAttribute(`style-override`, `:host { background: red; }`);
-        expect(getComponentStylesheetText(el)).to.equal(`:host { color: blue; }:host { background: red; }`);
+        el.setAttribute(`style-override`, `:host { background-color: red; }`);
+        expect(getComponentStylesheetText(el)).to.equal(`:host { color: blue; }:host { background-color: red; }`);
       });
     });
   });


### PR DESCRIPTION
This should mitigate potential breakage in new FF versions: https://github.com/mixpanel/panel/pull/153#discussion_r888401300

Replace `background: red;` with `background-color: red;` in tests because some browsers will expand `background: red;` to `background: red none repeat scroll 0% 0%;` in the component stylesheet object, which can cause test failures when we compare input and output style strings.