### PR TITLE
Improve TypeScript typing for Component.helpers

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -71,7 +71,7 @@ export interface PanelLifecycleContext {
   unbindFromComponent?(component: Component<any>): void;
 }
 
-export interface ConfigOptions<StateT, AppStateT = unknown, ContextRegistryT = unknown> {
+export interface ConfigOptions<StateT, AppStateT = unknown, ContextRegistryT = unknown, HelpersT extends PanelHelpers = unknown> {
   /** Function transforming state object to virtual dom tree */
   template(scope?: StateT): VNode;
 
@@ -94,7 +94,7 @@ export interface ConfigOptions<StateT, AppStateT = unknown, ContextRegistryT = u
   appState?: AppStateT;
 
   /** Properties and functions injected automatically into template state object */
-  helpers?: PanelHelpers;
+  helpers?: HelpersT;
 
   /** Extra rendering/lifecycle callbacks */
   hooks?: PanelHooks<StateT>;
@@ -153,7 +153,8 @@ export class Component<
   AttrsT = AnyAttrs,
   AppStateT = unknown,
   AppT = unknown,
-  ContextRegistryT = unknown
+  ContextRegistryT = unknown,
+  HelpersT extends PanelHelpers = unknown
 > extends WebComponent {
   /** The first Panel Component ancestor in the DOM tree; null if this component is the root */
   $panelParent: Component<unknown>;
@@ -198,7 +199,7 @@ export class Component<
   applyStaticStyle(styleSheetText: null | string, options?: {ignoreCache: boolean}): void;
 
   /** Defines standard component configuration */
-  get config(): ConfigOptions<StateT, AppStateT, ContextRegistryT>;
+  get config(): ConfigOptions<StateT, AppStateT, ContextRegistryT, HelpersT>;
 
   /**
    * Template helper functions defined in config object, and exposed to template code as $helpers.


### PR DESCRIPTION
Before this change (in PyCharm) navigating to `Component.helpers.someMethod`'s definition would always take me to https://github.com/mixpanel/panel/blob/74dc4c21b3e1729ae5c38298d0fac64c23e58cc2/lib/index.d.ts#L53. With these typing changes, it'll now navigate to the definition in `Component.config.helpers.someMethod`.